### PR TITLE
Extract file-modal template to a separate file

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -243,7 +243,7 @@ func (wb *Web) handleViewFile(w http.ResponseWriter, r *http.Request) {
 			"safe": func(s string) template.HTML {
 				return template.HTML(s) // nolint:gosec // safe to use with local embedded templates
 			},
-		}).ParseFS(content, "templates/index.html")
+		}).ParseFS(content, "templates/index.html", "templates/file-modal.html")
 		if err != nil {
 			log.Printf("[ERROR] failed to parse view template: %v", err)
 			http.Error(w, "error rendering file view", http.StatusInternalServerError)
@@ -416,7 +416,7 @@ func (wb *Web) handleDirContents(w http.ResponseWriter, r *http.Request) {
 		"safe": func(s string) template.HTML {
 			return template.HTML(s) // nolint:gosec // safe to use with local embedded templates
 		},
-	}).ParseFS(content, "templates/index.html")
+	}).ParseFS(content, "templates/index.html", "templates/file-modal.html")
 	if err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -495,7 +495,7 @@ func (wb *Web) renderFullPage(w http.ResponseWriter, r *http.Request, path strin
 		"safe": func(s string) template.HTML {
 			return template.HTML(s) // nolint:gosec // safe to use with local embedded templates
 		},
-	}).ParseFS(content, "templates/index.html")
+	}).ParseFS(content, "templates/index.html", "templates/file-modal.html")
 	if err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -972,12 +972,12 @@ func (wb *Web) handleFileModal(w http.ResponseWriter, r *http.Request) {
 		Theme:  wb.Config.Theme,
 	}
 
-	// parse the main template which contains all the named templates
+	// parse both templates
 	tmpl, err := template.New("index.html").Funcs(template.FuncMap{
 		"safe": func(s string) template.HTML {
 			return template.HTML(s) // nolint:gosec // safe to use with local embedded templates
 		},
-	}).ParseFS(content, "templates/index.html")
+	}).ParseFS(content, "templates/index.html", "templates/file-modal.html")
 	if err != nil {
 		log.Printf("[ERROR] failed to parse file-modal template: %v", err)
 		http.Error(w, "error rendering file modal", http.StatusInternalServerError)

--- a/server/templates/file-modal.html
+++ b/server/templates/file-modal.html
@@ -1,0 +1,34 @@
+{{ define "file-modal" }}
+<div class="file-modal">
+    <div class="modal-header">
+        <h3>{{ .FileName }}</h3>
+        <a href="#" class="close-modal" hx-on:click="document.getElementById('modal-container').innerHTML = ''">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
+            </svg>
+        </a>
+    </div>
+    <div class="modal-content">
+        {{ if .IsImage }}
+            <!-- For images, embed with img tag -->
+            <div class="loading-spinner"></div>
+            <img src="/view/{{ .FilePath }}" alt="{{ .FileName }}" class="modal-image" onload="this.style.opacity='1'; this.previousElementSibling.style.display='none';" style="opacity: 0; transition: opacity 0.2s;">
+        {{ else if .IsPDF }}
+            <!-- For PDFs, use an embed tag -->
+            <div class="loading-spinner"></div>
+            <embed src="/view/{{ .FilePath }}" type="application/pdf" width="100%" height="100%" style="opacity: 0; transition: opacity 0.2s;" onload="this.style.opacity='1'; this.previousElementSibling.style.display='none';">
+        {{ else if .IsHTML }}
+            <!-- For HTML files, use iframe to show rendered content -->
+            <div class="loading-spinner"></div>
+            <iframe src="/view/{{ .FilePath }}?theme={{ .Theme }}" class="text-preview" sandbox="allow-same-origin allow-scripts allow-forms" onload="this.style.opacity='1'; this.previousElementSibling.style.display='none';"></iframe>
+        {{ else if .IsText }}
+            <!-- For text files, use iframe to show content with theme -->
+            <div class="loading-spinner"></div>
+            <iframe src="/view/{{ .FilePath }}?theme={{ .Theme }}" class="text-preview" onload="this.style.opacity='1'; this.previousElementSibling.style.display='none';"></iframe>
+        {{ else }}
+            <!-- For unsupported file types -->
+            <div class="unsupported-file">This file type cannot be previewed. <a href="/{{ .FilePath }}" download>Download</a> the file to view it.</div>
+        {{ end }}
+    </div>
+</div>
+{{ end }}

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -100,41 +100,6 @@
 </html>
 {{ end }}
 
-{{ define "file-modal" }}
-<div class="file-modal">
-    <div class="modal-header">
-        <h3>{{ .FileName }}</h3>
-        <a href="#" class="close-modal" hx-on:click="document.getElementById('modal-container').innerHTML = ''">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-                <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
-            </svg>
-        </a>
-    </div>
-    <div class="modal-content">
-        {{ if .IsImage }}
-            <!-- For images, embed with img tag -->
-            <div class="loading-spinner"></div>
-            <img src="/view/{{ .FilePath }}" alt="{{ .FileName }}" class="modal-image" onload="this.style.opacity='1'; this.previousElementSibling.style.display='none';" style="opacity: 0; transition: opacity 0.2s;">
-        {{ else if .IsPDF }}
-            <!-- For PDFs, use an embed tag -->
-            <div class="loading-spinner"></div>
-            <embed src="/view/{{ .FilePath }}" type="application/pdf" width="100%" height="100%" style="opacity: 0; transition: opacity 0.2s;" onload="this.style.opacity='1'; this.previousElementSibling.style.display='none';">
-        {{ else if .IsHTML }}
-            <!-- For HTML files, use iframe to show rendered content -->
-            <div class="loading-spinner"></div>
-            <iframe src="/view/{{ .FilePath }}?theme={{ .Theme }}" class="text-preview" sandbox="allow-same-origin allow-scripts allow-forms" onload="this.style.opacity='1'; this.previousElementSibling.style.display='none';"></iframe>
-        {{ else if .IsText }}
-            <!-- For text files, use iframe to show content with theme -->
-            <div class="loading-spinner"></div>
-            <iframe src="/view/{{ .FilePath }}?theme={{ .Theme }}" class="text-preview" onload="this.style.opacity='1'; this.previousElementSibling.style.display='none';"></iframe>
-        {{ else }}
-            <!-- For unsupported file types -->
-            <div class="unsupported-file">This file type cannot be previewed. <a href="/{{ .FilePath }}" download>Download</a> the file to view it.</div>
-        {{ end }}
-    </div>
-</div>
-{{ end }}
-
 {{ define "page-content" }}
 <div class="breadcrumbs">
     <div class="path-parts">


### PR DESCRIPTION
## Summary
- Extract file-modal template from index.html to its own file-modal.html file
- Update template parsing to include both template files
- Improve code organization and maintainability

## Test plan
- Run tests with ok  	github.com/umputun/weblist	0.282s
ok  	github.com/umputun/weblist/server	0.601s
- Verify file modal functionality works correctly