### PR TITLE
Fix linting issues and improve error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "mocks" | grep -v "_mock" > $GITHUB_WORKSPACE/profile.cov
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
         version: v2.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.64
+        version: v2.0.2
 
     - name: install goveralls
       run: go install github.com/mattn/goveralls@latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,67 +1,82 @@
-run:
-  timeout: 5m
-  tests: false
-
-linters-settings:
-  govet:
-    enable:
-      - shadow
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-      - hugeParam
-      - rangeValCopy
-      - singleCaseSwitch
-      - ifElseChain
+version: "2"
 
 linters:
+  default: none
   enable:
-    - revive
-    - govet
-    - unconvert
-    - staticcheck
-    - unused
-    - gosec
-    - dupl
-    - misspell
-    - unparam
-    - typecheck
-    - ineffassign
-    - stylecheck
-    - gochecknoinits
     - copyloopvar
+    - dupl
+    - gochecknoinits
     - gocritic
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
     - nakedret
-    - gosimple
     - prealloc
-    - gofmt
-  fast: false
-  disable-all: true
+    - revive
+    - staticcheck
+    - unconvert
+    - unused
+    - testifylint
+    - unparam
+    - copyloopvar
+    - asciicheck
+    - contextcheck
+    - dogsled
+    - iface
+    - gocyclo
+    - lll
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - hugeParam
+        - rangeValCopy
+        - singleCaseSwitch
+        - ifElseChain
+        - octalLiteral
+        - httpNoBody
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    lll:
+      line-length: 140
+    gocyclo:
+      min-complexity: 15
 
-issues:
-  exclude-dirs:
-    - vendor
-  exclude-rules:
-    - text: "at least one file in a package should have a package comment"
-      linters:
-        - stylecheck
-    - text: "should have a package comment"
-      linters:
-        - revive
-    - path: _test\.go
-      linters:
-        - gosec
-        - dupl
-  exclude-use-default: false
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - revive
+        text: 'package-comments: should have a package comment'
+      - linters:
+          - staticcheck
+        text: at least one file in a package should have a package comment
+      - linters:
+          - dupl
+          - gosec
+          - testifylint
+        path: _test\.go
+      - linters:
+          - revive
+          - unused
+        path: _test\.go$
+        text: unused-parameter
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$
 
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## Summary

This PR addresses several issues with the codebase:

- Updates golangci-lint configuration to version 2 format and adds additional linters
- Properly handles errors in deferred file.Close() calls with defer func() { _ = file.Close() }()
- Fixes embedded field access (wb.Config.X -> wb.X) to match Go style recommendations
- Updates octal literals to modern format (0644 -> 0o644)
- Adds tests for error conditions in file handling operations
- Refactors main.go to extract a testable runServer function
- Fixes assertions in tests (assert.NoError -> require.NoError) where appropriate
- Removes unnecessary comments from test files
- Updates CI workflow to use golangci-lint v2.0.2

The PR improves test coverage and ensures proper error handling throughout the codebase.