### PR TITLE
Add support for custom footer text

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ weblist [options]
 - `-v, --version`: Show version and exit - env: `VERSION`
 - `--dbg`: Debug mode - env: `DEBUG`
 - `--syntax-highlight`: Enable syntax highlighting for code files - env: `SYNTAX_HIGHLIGHT`
+- `--custom-footer`: Custom footer text (can contain HTML) - env: `CUSTOM_FOOTER`
 
 SFTP Options (with `--sftp` prefix):
 - `--sftp.enabled`: Enable SFTP server - env: `SFTP_ENABLED`
@@ -170,17 +171,21 @@ weblist --brand.color "#3498db"
 # or
 weblist --brand.color "3498db"
 
-# Combine both branding options
-weblist --brand.name "My Company" --brand.color "#3498db"
+# Use a custom footer text (can contain HTML)
+weblist --custom-footer "Powered by <a href='https://example.com'>Example</a> | © 2025"
+
+# Combine branding options
+weblist --brand.name "My Company" --brand.color "#3498db" --custom-footer "© 2025 My Company"
 ```
 
 When branding is enabled:
 - Your organization name appears in the navigation bar
 - The specified color is applied to both the navigation bar and footer
+- Custom footer text replaces the default footer links (allows HTML links)
 - The branding is consistently displayed across all pages
 - These settings can be combined with all other Weblist options
 
-Custom branding is optional and only activated when the `--brand-name` and/or `--brand-color` parameters are provided.
+Custom branding is optional and only activated when the related parameters are provided.
 
 ## Docker
 
@@ -212,6 +217,7 @@ services:
       - AUTH=your_password  # Optional: Enable password authentication
       - BRAND_NAME=My Company  # Optional: Display company name in navbar
       - BRAND_COLOR=#3498db  # Optional: Custom color for navbar and footer
+      - CUSTOM_FOOTER="<a href='https://example.com'>Example</a> | © 2025"  # Optional: Custom footer text
       - SFTP_ENABLED=true   # Optional: Enable SFTP server
       - SFTP_USER=sftp_user # Optional: Username for SFTP access
       - SFTP_ADDRESS=:2022  # Optional: SFTP port

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ type options struct {
 	Exclude                  []string `short:"e" long:"exclude" env:"EXCLUDE" description:"files and directories to exclude (can be repeated)"`
 	Auth                     string   `short:"a" long:"auth" env:"AUTH" description:"password for basic auth (username is 'weblist')"`
 	Title                    string   `long:"title" env:"TITLE" description:"custom title for the site (used in browser title and home)"`
+	CustomFooter             string   `long:"custom-footer" env:"CUSTOM_FOOTER" description:"custom footer text (can contain HTML)"`
 	EnableSyntaxHighlighting bool     `long:"syntax-highlight" env:"SYNTAX_HIGHLIGHT" description:"enable syntax highlighting for code files"`
 
 	SFTP struct {
@@ -104,6 +105,7 @@ func runServer(ctx context.Context, opts *options) error {
 		Exclude:                  opts.Exclude,
 		Auth:                     opts.Auth,
 		Title:                    opts.Title,
+		CustomFooter:             opts.CustomFooter,
 		SFTPUser:                 opts.SFTP.User,
 		SFTPAddress:              opts.SFTP.Address,
 		SFTPKeyFile:              opts.SFTP.KeyFile,

--- a/server/server.go
+++ b/server/server.go
@@ -53,6 +53,7 @@ type Config struct {
 	BrandName                string   // company or organization name for branding
 	BrandColor               string   // color for navbar and footer
 	EnableSyntaxHighlighting bool     // whether to enable syntax highlighting for code files
+	CustomFooter             string   // custom footer text (can contain HTML)
 }
 
 // Run starts the web server.
@@ -229,6 +230,7 @@ func (wb *Web) handleDirContents(w http.ResponseWriter, r *http.Request) {
 		IsAuthenticated bool
 		BrandName       string
 		BrandColor      string
+		CustomFooter    string
 	}{
 		Files:           fileList,
 		Path:            path,
@@ -241,6 +243,7 @@ func (wb *Web) handleDirContents(w http.ResponseWriter, r *http.Request) {
 		BrandColor:      wb.BrandColor,
 		Title:           wb.Title,
 		IsAuthenticated: isAuthenticated,
+		CustomFooter:    wb.CustomFooter,
 	}
 
 	// execute just the page-content template
@@ -414,19 +417,21 @@ func (wb *Web) handleLoginPage(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	data := struct {
-		Theme      string
-		HideFooter bool
-		Title      string
-		Error      string
-		BrandName  string
-		BrandColor string
+		Theme        string
+		HideFooter   bool
+		Title        string
+		Error        string
+		BrandName    string
+		BrandColor   string
+		CustomFooter string
 	}{
-		Theme:      wb.Theme,
-		HideFooter: wb.HideFooter,
-		Title:      wb.Title,
-		BrandName:  wb.BrandName,
-		BrandColor: wb.BrandColor,
-		Error:      "", // empty error by default
+		Theme:        wb.Theme,
+		HideFooter:   wb.HideFooter,
+		Title:        wb.Title,
+		BrandName:    wb.BrandName,
+		BrandColor:   wb.BrandColor,
+		Error:        "", // empty error by default
+		CustomFooter: wb.CustomFooter,
 	}
 
 	if err := tmpl.Execute(w, data); err != nil {
@@ -462,6 +467,7 @@ func (wb *Web) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 			Error      string
 			BrandName  string
 			BrandColor string
+				CustomFooter string
 		}{
 			Theme:      wb.Theme,
 			HideFooter: wb.HideFooter,
@@ -469,6 +475,7 @@ func (wb *Web) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 			BrandName:  wb.BrandName,
 			BrandColor: wb.BrandColor,
 			Error:      "Invalid username or password",
+				CustomFooter: wb.CustomFooter,
 		}
 
 		if err := tmpl.Execute(w, data); err != nil {
@@ -721,6 +728,7 @@ func (wb *Web) renderFullPage(w http.ResponseWriter, r *http.Request, path strin
 		Title           string
 		BrandName       string
 		BrandColor      string
+		CustomFooter    string
 	}{
 		Files:           fileList,
 		Path:            path,
@@ -734,6 +742,7 @@ func (wb *Web) renderFullPage(w http.ResponseWriter, r *http.Request, path strin
 		Title:           wb.Title,
 		BrandName:       wb.BrandName,
 		BrandColor:      wb.BrandColor,
+		CustomFooter:    wb.CustomFooter,
 	}
 
 	// execute the entire template

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1781,6 +1781,54 @@ func TestTitleFunctionality(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "<title>Login - Custom Title</title>")
 }
 
+func TestCustomFooter(t *testing.T) {
+	// create a server with a custom footer
+	testdataDir, err := filepath.Abs("testdata")
+	require.NoError(t, err)
+
+	customFooterHTML := "Custom Footer <a href=\"https://example.com\">with a link</a>"
+
+	srv := &Web{
+		Config: Config{
+			ListenAddr:   ":0",
+			Theme:        "light",
+			RootDir:      testdataDir,
+			CustomFooter: customFooterHTML,
+		},
+		FS: os.DirFS(testdataDir),
+	}
+
+	// test custom footer appears in the index page
+	req, err := http.NewRequest("GET", "/", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(srv.handleRoot)
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// check that the custom footer appears in the HTML
+	assert.Contains(t, rr.Body.String(), customFooterHTML)
+
+	// check that the default footer links don't appear
+	assert.NotContains(t, rr.Body.String(), "https://weblist.umputun.dev")
+	assert.NotContains(t, rr.Body.String(), "https://github.com/umputun/weblist")
+
+	// test custom footer appears in the login page too
+	req, err = http.NewRequest("GET", "/login", nil)
+	require.NoError(t, err)
+
+	rr = httptest.NewRecorder()
+	handler = http.HandlerFunc(srv.handleLoginPage)
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// check that the custom footer appears in the login page HTML
+	assert.Contains(t, rr.Body.String(), customFooterHTML)
+}
+
 // Skip TestHandleLoginPage as templates are embedded and tests are failing
 
 func TestHandleLoginSubmit(t *testing.T) {

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -20,6 +20,9 @@
 {{ if not .HideFooter }}
 <footer{{ if .BrandColor }} style="background-color: {{ .BrandColor }}"{{ end }}>
     <div class="footer-content">
+        {{ if .CustomFooter }}
+            {{ .CustomFooter | safe }}
+        {{ else }}
         <span class="footer-item">
             <a href="https://weblist.umputun.dev" class="footer-link">
                 <img src="/assets/favicon.png" class="footer-icon" width="14" height="14" alt="weblist" style="filter: brightness(0) invert(1);"/>
@@ -44,6 +47,7 @@
                 GitHub
             </a>
         </span>
+        {{ end }}
     </div>
 </footer>
 {{ end }}

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -52,6 +52,9 @@
 {{ if not .HideFooter }}
 <footer{{ if .BrandColor }} style="background-color: {{ .BrandColor }}"{{ end }}>
     <div class="footer-content">
+        {{ if .CustomFooter }}
+            {{ .CustomFooter | safe }}
+        {{ else }}
         <span class="footer-item">
             <a href="https://weblist.umputun.dev" class="footer-link">
                 <img src="/assets/favicon.png" class="footer-icon" width="14" height="14" alt="weblist" style="filter: brightness(0) invert(1);"/>
@@ -76,6 +79,7 @@
                 GitHub
             </a>
         </span>
+        {{ end }}
     </div>
 </footer>
 {{ end }}


### PR DESCRIPTION
## Summary
- Added a new CustomFooter field to the Config struct
- Updated templates to display custom footer text when provided
- Added command-line flag and environment variable support
- Added appropriate tests for the new feature
- Updated documentation

This change allows users to specify custom footer text (including HTML) via the --custom-footer flag or CUSTOM_FOOTER environment variable. The custom footer will replace the default footer links when provided.