### PR TITLE
Fix: Remove brand color from footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ SFTP Options (with `--sftp` prefix):
 
 Branding Options (with `--brand` prefix):
 - `--brand.name`: Company or organization name to display in navbar - env: `BRAND_NAME`
-- `--brand.color`: Color for navbar and footer (e.g. `3498db` or `#3498db`) - env: `BRAND_COLOR`
+- `--brand.color`: Color for navbar (e.g. `3498db` or `#3498db`) - env: `BRAND_COLOR`
 
 ## Authentication
 
@@ -166,7 +166,7 @@ Weblist allows you to customize the appearance with your organization's branding
 # Set a custom organization name in the navigation bar
 weblist --brand.name "My Company"
 
-# Set a custom color for the navigation bar and footer (with or without # prefix)
+# Set a custom color for the navigation bar (with or without # prefix)
 weblist --brand.color "#3498db"
 # or
 weblist --brand.color "3498db"
@@ -180,7 +180,7 @@ weblist --brand.name "My Company" --brand.color "#3498db" --custom-footer "© 20
 
 When branding is enabled:
 - Your organization name appears in the navigation bar
-- The specified color is applied to both the navigation bar and footer
+- The specified color is applied to the navigation bar
 - Custom footer text replaces the default footer links (allows HTML links)
 - The branding is consistently displayed across all pages
 - These settings can be combined with all other Weblist options
@@ -216,7 +216,7 @@ services:
       - EXCLUDE=.git,.env
       - AUTH=your_password  # Optional: Enable password authentication
       - BRAND_NAME=My Company  # Optional: Display company name in navbar
-      - BRAND_COLOR=#3498db  # Optional: Custom color for navbar and footer
+      - BRAND_COLOR=#3498db  # Optional: Custom color for navbar
       - CUSTOM_FOOTER="<a href='https://example.com'>Example</a> | © 2025"  # Optional: Custom footer text
       - SFTP_ENABLED=true   # Optional: Enable SFTP server
       - SFTP_USER=sftp_user # Optional: Username for SFTP access

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ type options struct {
 
 	Branding struct {
 		Name  string `long:"name" env:"NAME" description:"company or organization name to display in navbar"`
-		Color string `long:"color" env:"COLOR" description:"color for navbar and footer (e.g. #3498db or 3498db)"`
+		Color string `long:"color" env:"COLOR" description:"color for navbar (e.g. #3498db or 3498db)"`
 	} `group:"Branding options" namespace:"brand" env-namespace:"BRAND"`
 
 	HideFooter bool `short:"f" long:"hide-footer" env:"HIDE_FOOTER"  description:"hide footer"`

--- a/server/server.go
+++ b/server/server.go
@@ -51,7 +51,7 @@ type Config struct {
 	SFTPKeyFile              string   // path to SSH private key file
 	SFTPAuthorized           string   // path to authorized_keys file for public key authentication
 	BrandName                string   // company or organization name for branding
-	BrandColor               string   // color for navbar and footer
+	BrandColor               string   // color for navbar
 	EnableSyntaxHighlighting bool     // whether to enable syntax highlighting for code files
 	CustomFooter             string   // custom footer text (can contain HTML)
 }

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -18,7 +18,7 @@
 </main>
 <div id="modal-container" hx-on:click="if(event.target === this) this.innerHTML = ''"></div>
 {{ if not .HideFooter }}
-<footer{{ if .BrandColor }} style="background-color: {{ .BrandColor }}"{{ end }}>
+<footer>
     <div class="footer-content">
         {{ if .CustomFooter }}
             {{ .CustomFooter | safe }}

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -50,7 +50,7 @@
 </main>
 
 {{ if not .HideFooter }}
-<footer{{ if .BrandColor }} style="background-color: {{ .BrandColor }}"{{ end }}>
+<footer>
     <div class="footer-content">
         {{ if .CustomFooter }}
             {{ .CustomFooter | safe }}


### PR DESCRIPTION
## Summary
- Removes brand color styling from footer to maintain the subtle styling independent of branding
- Updates documentation to clarify that brand color only applies to the navbar
- Ensures consistent styling between footer and navbar

The custom brand color is now only applied to the navbar, not the footer. This maintains the subtle footer styling we introduced earlier and avoids conflicts with custom footer text.