### PR TITLE
Add multiple file selection and download functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A modern, elegant file browser for the web. Weblist provides a clean and intuiti
 - **No Setup Required**: Single binary that just works - no configuration needed
 - **Dark Mode**: Easy on the eyes with both light and dark themes
 - **Optional Authentication**: Password-protect your file listings when needed
+- **Multi-file Selection**: Select and download multiple files as a ZIP archive (optional)
 - **SFTP Support**: Access the same files via SFTP for more advanced operations
 - **Syntax Highlighting**: Beautiful code highlighting for various programming languages (optional)
 - **JSON API**: Programmatic access to file listings via a simple JSON API
@@ -58,6 +59,9 @@ weblist --auth your_password
 
 # Enable syntax highlighting for code files
 weblist --syntax-highlight
+
+# Enable multi-file selection and download
+weblist --multi
 ```
 
 ## Installation
@@ -101,6 +105,7 @@ weblist [options]
 - `--dbg`: Debug mode - env: `DEBUG`
 - `--syntax-highlight`: Enable syntax highlighting for code files - env: `SYNTAX_HIGHLIGHT`
 - `--custom-footer`: Custom footer text (can contain HTML) - env: `CUSTOM_FOOTER`
+- `--multi`: Enable multi-file selection and download - env: `MULTI_SELECT`
 
 SFTP Options (with `--sftp` prefix):
 - `--sftp.enabled`: Enable SFTP server - env: `SFTP_ENABLED`
@@ -176,6 +181,27 @@ When SFTP is enabled:
   - You can specify a custom key file with `--sftp.key`
 
 SFTP support is optional and only enabled when both `--sftp.enabled` and `--sftp.user` parameters are provided. Either the `--auth` or `--sftp.authorized` parameter is required when enabling SFTP.
+
+## Multi-file Selection
+
+Weblist can optionally allow users to select and download multiple files at once:
+
+```bash
+# Enable multi-file selection and download
+weblist --multi
+```
+
+When multi-file selection is enabled:
+
+- Checkboxes appear next to each file and directory in the listing
+- A "Select All" checkbox appears in the header for batch selection
+- Selected files and directories are counted and displayed in the header
+- A "Download Selected" button appears when at least one item is selected
+- Clicking the button downloads all selected items as a single ZIP archive
+- Entire directories with their contents can be selected and downloaded
+- The feature works seamlessly in both light and dark themes
+
+Multi-file selection is disabled by default for a cleaner interface and can be enabled with the `--multi` flag.
 
 ## Custom Branding
 
@@ -339,4 +365,5 @@ services:
       - SFTP_KEY=/data/ssh_key  # Optional: Path to SSH host key
       - SFTP_AUTHORIZED=/data/authorized_keys  # Optional: Path to authorized_keys file for public key auth
       - SYNTAX_HIGHLIGHT=true  # Optional: Enable syntax highlighting for code files
+      - MULTI_SELECT=true  # Optional: Enable multi-file selection and download
 ```

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type options struct {
 	HideFooter               bool   `short:"f" long:"hide-footer" env:"HIDE_FOOTER"  description:"hide footer"`
 	CustomFooter             string `long:"custom-footer" env:"CUSTOM_FOOTER" description:"custom footer text (can contain HTML)"`
 	EnableSyntaxHighlighting bool   `long:"syntax-highlight" env:"SYNTAX_HIGHLIGHT" description:"enable syntax highlighting"`
+	EnableMultiSelect        bool   `long:"multi" env:"MULTI_SELECT" description:"enable multi-file selection and download"`
 
 	InsecureCookies bool          `long:"insecure-cookies" env:"INSECURE_COOKIES" description:"allow cookies without secure flag"`
 	SessionTTL      time.Duration `long:"session-ttl" env:"SESSION_TTL" default:"24h" description:"session timeout"`
@@ -123,6 +124,7 @@ func runServer(ctx context.Context, opts *options) error {
 		BrandColor:               opts.Branding.Color,
 		InsecureCookies:          opts.InsecureCookies,
 		SessionTTL:               opts.SessionTTL,
+		EnableMultiSelect:        opts.EnableMultiSelect,
 	}
 
 	// create HTTP server

--- a/server/assets/css/weblist-app.css
+++ b/server/assets/css/weblist-app.css
@@ -7,7 +7,23 @@ table {
 }
 
 /* Column widths for consistency */
-table th.select-col, table td.select-cell { width: 40px; text-align: center; }
+table th.select-col, table td.select-cell { 
+  width: 40px; 
+  min-width: 40px;
+  text-align: center; 
+  vertical-align: middle;
+  padding-left: var(--spacing-xs);
+  padding-right: var(--spacing-xs);
+}
+table th.select-col input[type="checkbox"],
+table td.select-cell input[type="checkbox"] {
+  margin: 0;
+  vertical-align: middle;
+  position: relative;
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+}
 table th:nth-child(2), table td:nth-child(2) { width: 55%; }
 table th:nth-child(3), table td:nth-child(3) { width: 25%; }
 table th:nth-child(4), table td:nth-child(4) { width: 15%; }
@@ -537,6 +553,10 @@ pre {
   border: 1px solid var(--color-border);
 }
 
+[data-theme="dark"] input[type="checkbox"] {
+  accent-color: #888; /* Muted color for dark theme checkboxes */
+}
+
 
 .logout-icon {
   vertical-align: middle;
@@ -546,34 +566,49 @@ pre {
 /* Multi-file selection styles */
 .actions-container {
   display: flex;
+  flex-wrap: nowrap;
   align-items: center;
-  gap: var(--spacing-md);
+  justify-content: flex-end;
+  gap: var(--spacing-lg);
+  margin-left: auto;
 }
 
 .selection-status {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
+  gap: var(--spacing-md);
+}
+
+#selection-status form {
+  display: inline-flex; 
+  margin: 0;
+  vertical-align: middle;
 }
 
 .selected-count {
   color: var(--color-white);
   font-size: 0.9rem;
+  font-weight: 500;
   white-space: nowrap;
 }
 
 .download-selected-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: var(--spacing-xs);
   padding: 0.3rem 0.6rem;
   background-color: var(--color-white-overlay);
   color: var(--color-white);
-  border: none;
+  border: 1px solid var(--color-white-overlay);
   border-radius: var(--border-radius-sm);
   cursor: pointer;
   font-size: 0.9rem;
+  font-weight: 500;
   transition: background-color 0.2s;
+  white-space: nowrap;
+  text-align: center;
+  margin-left: 0.5rem;
 }
 
 .download-selected-btn:hover {
@@ -584,27 +619,57 @@ pre {
   fill: var(--color-white) !important;
   width: 16px;
   height: 16px;
+  flex-shrink: 0;
+}
+
+/* Breadcrumbs layout */
+.breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1rem;
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 2px 10px var(--color-shadow);
+  margin-bottom: var(--spacing-md);
+  border-radius: var(--border-radius-md);
 }
 
 /* Responsive adjustments for selection elements */
 @media (max-width: 768px) {
   .breadcrumbs {
-    grid-template-columns: 1fr auto auto;
-    grid-template-areas:
-      "path selection logout";
+    flex-direction: column;
+    align-items: flex-start;
+    row-gap: var(--spacing-sm);
   }
   
   .path-parts {
-    max-width: calc(100% - 200px);
+    width: 100%;
+    overflow: auto;
+    margin-bottom: var(--spacing-xs);
+  }
+  
+  .actions-container {
+    width: 100%;
+    margin-top: var(--spacing-sm);
+    display: flex;
+    justify-content: space-between;
   }
   
   .selection-status {
-    grid-area: selection;
+    width: 100%;
+    justify-content: flex-start;
+    margin-left: 0;
   }
   
   .download-selected-btn {
     padding: 0.2rem 0.4rem;
     font-size: 0.8rem;
+    white-space: nowrap;
   }
   
   .selected-count {

--- a/server/assets/css/weblist-app.css
+++ b/server/assets/css/weblist-app.css
@@ -7,9 +7,10 @@ table {
 }
 
 /* Column widths for consistency */
-table th:first-child, table td:first-child { width: 60%; }
-table th:nth-child(2), table td:nth-child(2) { width: 25%; }
-table th:nth-child(3), table td:nth-child(3) { width: 15%; }
+table th.select-col, table td.select-cell { width: 40px; text-align: center; }
+table th:nth-child(2), table td:nth-child(2) { width: 55%; }
+table th:nth-child(3), table td:nth-child(3) { width: 25%; }
+table th:nth-child(4), table td:nth-child(4) { width: 15%; }
 
 /* Ensure all column headers have the same styling */
 table th.date-col, table th.size-col {
@@ -540,4 +541,73 @@ pre {
 .logout-icon {
   vertical-align: middle;
   margin-right: 0.25rem;
+}
+
+/* Multi-file selection styles */
+.actions-container {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.selection-status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.selected-count {
+  color: var(--color-white);
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.download-selected-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 0.3rem 0.6rem;
+  background-color: var(--color-white-overlay);
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--border-radius-sm);
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s;
+}
+
+.download-selected-btn:hover {
+  background-color: var(--color-white-overlay-hover);
+}
+
+.download-selected-btn svg {
+  fill: var(--color-white) !important;
+  width: 16px;
+  height: 16px;
+}
+
+/* Responsive adjustments for selection elements */
+@media (max-width: 768px) {
+  .breadcrumbs {
+    grid-template-columns: 1fr auto auto;
+    grid-template-areas:
+      "path selection logout";
+  }
+  
+  .path-parts {
+    max-width: calc(100% - 200px);
+  }
+  
+  .selection-status {
+    grid-area: selection;
+  }
+  
+  .download-selected-btn {
+    padding: 0.2rem 0.4rem;
+    font-size: 0.8rem;
+  }
+  
+  .selected-count {
+    font-size: 0.8rem;
+  }
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1422,14 +1422,17 @@ func (wb *Web) handleSelectionStatus(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// if all files are selected, then unselect all
+		// check if we're toggling from "all selected" to "none selected" state
+		// if the number of selected files matches the total, we're in "all selected" state
 		if len(selectedFiles) == totalFiles {
+			// toggle to "none selected" state
 			checkState = false
 			selectedFiles = []string{} // clear the selection
 		} else {
-			// otherwise, we want to select all files
-			// get all path-values from the form
+			// otherwise, we're toggling from "none selected" or "partially selected" to "all selected"
+			// get path values for all files in the current directory
 			selectedFiles = r.Form["path-values"]
+			// set checkboxes to checked state
 			checkState = true
 		}
 	} else {

--- a/server/server.go
+++ b/server/server.go
@@ -75,6 +75,7 @@ type Config struct {
 	CustomFooter             string        // custom footer text (can contain HTML)
 	InsecureCookies          bool          // allow cookies without secure flag
 	SessionTTL               time.Duration // session timeout duration
+	EnableMultiSelect        bool          // enable multi-file selection and download
 }
 
 // Run starts the web server.
@@ -319,31 +320,33 @@ func (wb *Web) handleDirContents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		Files           []FileInfo
-		Path            string
-		DisplayPath     string
-		SortBy          string
-		SortDir         string
-		PathParts       []map[string]string
-		Theme           string
-		Title           string
-		IsAuthenticated bool
-		BrandName       string
-		BrandColor      string
-		CustomFooter    string
+		Files             []FileInfo
+		Path              string
+		DisplayPath       string
+		SortBy            string
+		SortDir           string
+		PathParts         []map[string]string
+		Theme             string
+		Title             string
+		IsAuthenticated   bool
+		BrandName         string
+		BrandColor        string
+		CustomFooter      string
+		EnableMultiSelect bool
 	}{
-		Files:           fileList,
-		Path:            path,
-		DisplayPath:     displayPath,
-		SortBy:          sortBy,
-		SortDir:         sortDir,
-		PathParts:       wb.getPathParts(path, sortBy, sortDir),
-		Theme:           wb.Theme,
-		BrandName:       wb.BrandName,
-		BrandColor:      wb.BrandColor,
-		Title:           wb.Title,
-		IsAuthenticated: isAuthenticated,
-		CustomFooter:    wb.CustomFooter,
+		Files:             fileList,
+		Path:              path,
+		DisplayPath:       displayPath,
+		SortBy:            sortBy,
+		SortDir:           sortDir,
+		PathParts:         wb.getPathParts(path, sortBy, sortDir),
+		Theme:             wb.Theme,
+		BrandName:         wb.BrandName,
+		BrandColor:        wb.BrandColor,
+		Title:             wb.Title,
+		IsAuthenticated:   isAuthenticated,
+		CustomFooter:      wb.CustomFooter,
+		EnableMultiSelect: wb.EnableMultiSelect,
 	}
 
 	// execute just the page-content template
@@ -862,33 +865,35 @@ func (wb *Web) renderFullPage(w http.ResponseWriter, r *http.Request, path strin
 	}
 
 	data := struct {
-		Files           []FileInfo
-		Path            string
-		DisplayPath     string
-		SortBy          string
-		SortDir         string
-		PathParts       []map[string]string
-		Theme           string
-		HideFooter      bool
-		IsAuthenticated bool
-		Title           string
-		BrandName       string
-		BrandColor      string
-		CustomFooter    string
+		Files             []FileInfo
+		Path              string
+		DisplayPath       string
+		SortBy            string
+		SortDir           string
+		PathParts         []map[string]string
+		Theme             string
+		HideFooter        bool
+		IsAuthenticated   bool
+		Title             string
+		BrandName         string
+		BrandColor        string
+		CustomFooter      string
+		EnableMultiSelect bool
 	}{
-		Files:           fileList,
-		Path:            path,
-		DisplayPath:     displayPath,
-		SortBy:          sortBy,
-		SortDir:         sortDir,
-		PathParts:       wb.getPathParts(path, sortBy, sortDir),
-		Theme:           wb.Theme,
-		HideFooter:      wb.HideFooter,
-		IsAuthenticated: isAuthenticated,
-		Title:           wb.Title,
-		BrandName:       wb.BrandName,
-		BrandColor:      wb.BrandColor,
-		CustomFooter:    wb.CustomFooter,
+		Files:             fileList,
+		Path:              path,
+		DisplayPath:       displayPath,
+		SortBy:            sortBy,
+		SortDir:           sortDir,
+		PathParts:         wb.getPathParts(path, sortBy, sortDir),
+		Theme:             wb.Theme,
+		HideFooter:        wb.HideFooter,
+		IsAuthenticated:   isAuthenticated,
+		Title:             wb.Title,
+		BrandName:         wb.BrandName,
+		BrandColor:        wb.BrandColor,
+		CustomFooter:      wb.CustomFooter,
+		EnableMultiSelect: wb.EnableMultiSelect,
 	}
 
 	// execute the entire template

--- a/server/server.go
+++ b/server/server.go
@@ -1405,6 +1405,29 @@ func (wb *Web) handleSelectionStatus(w http.ResponseWriter, r *http.Request) {
 	selectedFiles := r.Form["selected-files"]
 	selectAll := r.FormValue("select-all")
 
+	// toggle logic for select-all
+	var checkState bool
+	if selectAll == "true" {
+		// if select-all is clicked, we need to toggle between selected and unselected
+		// get the total number of files from the form
+		totalFilesStr := r.FormValue("total-files")
+		totalFiles, _ := strconv.Atoi(totalFilesStr)
+
+		// if all files are selected, then unselect all
+		if len(selectedFiles) == totalFiles {
+			checkState = false
+			selectedFiles = []string{} // clear the selection
+		} else {
+			// otherwise, we want to select all files
+			// get all path-values from the form
+			selectedFiles = r.Form["path-values"]
+			checkState = true
+		}
+	} else {
+		// regular checkbox update - just use the current selection
+		checkState = len(selectedFiles) > 0
+	}
+
 	// prepare template data
 	data := struct {
 		Count         int
@@ -1415,7 +1438,7 @@ func (wb *Web) handleSelectionStatus(w http.ResponseWriter, r *http.Request) {
 		Count:         len(selectedFiles),
 		SelectedFiles: selectedFiles,
 		SelectAll:     selectAll == "true",
-		CheckState:    len(selectedFiles) > 0,
+		CheckState:    checkState,
 	}
 
 	// execute the selection-status template

--- a/server/server.go
+++ b/server/server.go
@@ -1416,7 +1416,11 @@ func (wb *Web) handleSelectionStatus(w http.ResponseWriter, r *http.Request) {
 		// if select-all is clicked, we need to toggle between selected and unselected
 		// get the total number of files from the form
 		totalFilesStr := r.FormValue("total-files")
-		totalFiles, _ := strconv.Atoi(totalFilesStr)
+		totalFiles, err := strconv.Atoi(totalFilesStr)
+		if err != nil {
+			http.Error(w, "Invalid total-files value", http.StatusBadRequest)
+			return
+		}
 
 		// if all files are selected, then unselect all
 		if len(selectedFiles) == totalFiles {

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -109,8 +109,8 @@
                        hx-post="/partials/selection-status"
                        hx-trigger="click"
                        hx-target="#selection-status"
-                       hx-include=".file-checkbox"
-                       hx-vals='{"select-all": "true"}'
+                       hx-include=".file-checkbox, .path-value"
+                       hx-vals='{"select-all": "true", "total-files": "{{ len .Files }}"}'
                        hx-swap="innerHTML">
             </th>
             <th hx-get="/partials/dir-contents"
@@ -138,6 +138,9 @@
         </thead>
         <tbody>
         {{ range .Files }}
+        {{ if ne .Name ".." }}
+        <input type="hidden" class="path-value" name="path-values" value="{{.Path}}">
+        {{ end }}
         {{ if .IsDir }}
         <!-- Directory row: Make the entire row clickable -->
         <tr class="dir-row" 
@@ -153,7 +156,7 @@
                        hx-post="/partials/selection-status"
                        hx-trigger="click"
                        hx-target="#selection-status"
-                       hx-include=".file-checkbox"
+                       hx-include=".file-checkbox, .path-value"
                        onclick="event.stopPropagation();"
                        title="Select directory">
                 {{ end }}
@@ -178,7 +181,7 @@
                        hx-post="/partials/selection-status"
                        hx-trigger="click"
                        hx-target="#selection-status"
-                       hx-include=".file-checkbox"
+                       hx-include=".file-checkbox, .path-value"
                        title="Select file">
             </td>
             <td class="name-cell">

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -64,7 +64,6 @@
         <!-- Home link with HTMX - no URL push -->
         <a href="#"
            hx-get="/partials/dir-contents"
-
            hx-vals='{"path": ".", "sort": "{{$.SortBy}}", "dir": "{{$.SortDir}}"}'
            hx-target="#page-content">
             <svg class="icon dir-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
@@ -83,22 +82,37 @@
         {{ end }}
         {{ end }}
     </div>
-    {{ if .IsAuthenticated }}
-    <div class="logout-button">
-        <a href="/logout">
-            <svg class="logout-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-                <path fill-rule="evenodd" d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0v2z"/>
-                <path fill-rule="evenodd" d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3z"/>
-            </svg>
-            Logout
-        </a>
+    
+    <div class="actions-container">
+        <!-- Selection status and download button container -->
+        <div id="selection-status" class="selection-status"></div>
+        
+        {{ if .IsAuthenticated }}
+        <div class="logout-button">
+            <a href="/logout">
+                <svg class="logout-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0v2z"/>
+                    <path fill-rule="evenodd" d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3z"/>
+                </svg>
+                Logout
+            </a>
+        </div>
+        {{ end }}
     </div>
-    {{ end }}
 </div>
 <article>
     <table role="grid">
         <thead>
         <tr>
+            <th class="select-col">
+                <input type="checkbox" id="select-all" title="Select all files" 
+                       hx-post="/partials/selection-status"
+                       hx-trigger="click"
+                       hx-target="#selection-status"
+                       hx-include=".file-checkbox"
+                       hx-vals='{"select-all": "true"}'
+                       hx-swap="innerHTML">
+            </th>
             <th hx-get="/partials/dir-contents"
                 hx-vals='{"path": "{{ .Path }}", "sort": "name", "dir": {{ if and (eq .SortBy "name") (eq .SortDir "asc") }}"desc"{{ else }}"asc"{{ end }}}'
                 hx-target="#page-content"
@@ -130,6 +144,20 @@
             hx-get="/partials/dir-contents"
             hx-vals='{"path": "{{.Path}}", "sort": "{{$.SortBy}}", "dir": "{{$.SortDir}}"}'
             hx-target="#page-content">
+            <td class="select-cell">
+                {{ if eq .Name ".." }}
+                <!-- No checkbox for parent directory -->
+                {{ else }}
+                <!-- Checkbox for directory -->
+                <input type="checkbox" class="file-checkbox" name="selected-files" value="{{.Path}}" 
+                       hx-post="/partials/selection-status"
+                       hx-trigger="click"
+                       hx-target="#selection-status"
+                       hx-include=".file-checkbox"
+                       onclick="event.stopPropagation();"
+                       title="Select directory">
+                {{ end }}
+            </td>
             <td class="name-cell">
                 <!-- Directory entry with icon -->
                 <div class="dir-entry">
@@ -143,8 +171,16 @@
             <td>{{ .SizeToString }}</td>
         </tr>
         {{ else }}
-        <!-- File row: Keep current behavior -->
+        <!-- File row -->
         <tr>
+            <td class="select-cell">
+                <input type="checkbox" class="file-checkbox" name="selected-files" value="{{.Path}}" 
+                       hx-post="/partials/selection-status"
+                       hx-trigger="click"
+                       hx-target="#selection-status"
+                       hx-include=".file-checkbox"
+                       title="Select file">
+            </td>
             <td class="name-cell">
                 <div class="file-entry">
                     <!-- File: Link to download handler -->

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -85,7 +85,9 @@
     
     <div class="actions-container">
         <!-- Selection status and download button container -->
+        {{ if .EnableMultiSelect }}
         <div id="selection-status" class="selection-status"></div>
+        {{ end }}
         
         {{ if .IsAuthenticated }}
         <div class="logout-button">
@@ -104,6 +106,7 @@
     <table role="grid">
         <thead>
         <tr>
+            {{ if .EnableMultiSelect }}
             <th class="select-col">
                 <input type="checkbox" id="select-all" title="Select all files" 
                        hx-post="/partials/selection-status"
@@ -113,6 +116,7 @@
                        hx-vals='{"select-all": "true", "total-files": "{{ len .Files }}"}'
                        hx-swap="innerHTML">
             </th>
+            {{ end }}
             <th hx-get="/partials/dir-contents"
                 hx-vals='{"path": "{{ .Path }}", "sort": "name", "dir": {{ if and (eq .SortBy "name") (eq .SortDir "asc") }}"desc"{{ else }}"asc"{{ end }}}'
                 hx-target="#page-content"
@@ -138,7 +142,7 @@
         </thead>
         <tbody>
         {{ range .Files }}
-        {{ if ne .Name ".." }}
+        {{ if and (ne .Name "..") ($.EnableMultiSelect) }}
         <input type="hidden" class="path-value" name="path-values" value="{{.Path}}">
         {{ end }}
         {{ if .IsDir }}
@@ -147,6 +151,7 @@
             hx-get="/partials/dir-contents"
             hx-vals='{"path": "{{.Path}}", "sort": "{{$.SortBy}}", "dir": "{{$.SortDir}}"}'
             hx-target="#page-content">
+            {{ if $.EnableMultiSelect }}
             <td class="select-cell">
                 {{ if eq .Name ".." }}
                 <!-- No checkbox for parent directory -->
@@ -161,6 +166,7 @@
                        title="Select directory">
                 {{ end }}
             </td>
+            {{ end }}
             <td class="name-cell">
                 <!-- Directory entry with icon -->
                 <div class="dir-entry">
@@ -176,6 +182,7 @@
         {{ else }}
         <!-- File row -->
         <tr>
+            {{ if $.EnableMultiSelect }}
             <td class="select-cell">
                 <input type="checkbox" class="file-checkbox" name="selected-files" value="{{.Path}}" 
                        hx-post="/partials/selection-status"
@@ -184,6 +191,7 @@
                        hx-include=".file-checkbox, .path-value"
                        title="Select file">
             </td>
+            {{ end }}
             <td class="name-cell">
                 <div class="file-entry">
                     <!-- File: Link to download handler -->

--- a/server/templates/selection-status.html
+++ b/server/templates/selection-status.html
@@ -4,7 +4,7 @@
     <span class="selected-count">
         {{ if eq .Count 1 }}1 file selected{{ else }}{{ .Count }} files selected{{ end }}
     </span>
-    <form action="/download-selected" method="post" target="_blank">
+    <form action="/download-selected" method="post">
         {{ range .SelectedFiles }}
         <input type="hidden" name="selected-files" value="{{ . }}">
         {{ end }}

--- a/server/templates/selection-status.html
+++ b/server/templates/selection-status.html
@@ -1,0 +1,27 @@
+{{ define "selection-status" }}
+<div id="selection-status" class="selection-status">
+    {{ if gt .Count 0 }}
+    <span class="selected-count">
+        {{ if eq .Count 1 }}1 file selected{{ else }}{{ .Count }} files selected{{ end }}
+    </span>
+    <form action="/download-selected" method="post" target="_blank">
+        {{ range .SelectedFiles }}
+        <input type="hidden" name="selected-files" value="{{ . }}">
+        {{ end }}
+        <button type="submit" class="download-selected-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/>
+                <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"/>
+            </svg>
+            Download Selected
+        </button>
+    </form>
+    {{ end }}
+</div>
+{{ if .SelectAll }}
+<script>
+    document.querySelectorAll('.file-checkbox').forEach(cb => cb.checked = {{ .CheckState }});
+    document.getElementById('select-all').checked = {{ .CheckState }};
+</script>
+{{ end }}
+{{ end }}


### PR DESCRIPTION
## Summary
- Implemented a new feature that allows users to select and download multiple files as a ZIP archive
- Made multi-select optional and disabled by default, can be enabled with the new `--multi` flag 
- Added UI components for file selection including checkboxes and download button
- Implemented server-side handling for creating ZIP archives of selected files

Fixes #28