### PR TITLE
Add --recursive-mtime flag for directory sorting

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -142,6 +142,7 @@ jobs:
         id: tags
         run: |
           branch="${{ github.event.workflow_run.head_branch }}"
+          branch="${branch//\//_}"  # replace / with _ for valid docker tags
           echo "branch=${branch}" >> $GITHUB_OUTPUT
           if [[ "$branch" == v* ]]; then
             echo "is_tag=true" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ weblist [options]
 - `--syntax-highlight`: Enable syntax highlighting for code files - env: `SYNTAX_HIGHLIGHT`
 - `--custom-footer`: Custom footer text (can contain HTML) - env: `CUSTOM_FOOTER`
 - `--multi`: Enable multi-file selection and download - env: `MULTI_SELECT`
+- `--recursive-mtime`: Calculate directory mtime from newest nested file - env: `RECURSIVE_MTIME`
 - `--title`: Custom title for the site (used in browser title and home) - env: `TITLE`
 
 SFTP Options (with `--sftp` prefix):
@@ -206,6 +207,19 @@ When multi-file selection is enabled:
 - The feature works seamlessly in both light and dark themes
 
 Multi-file selection is disabled by default for a cleaner interface and can be enabled with the `--multi` flag.
+
+## Recursive Directory Modification Time
+
+By default, when sorting by date, directories show their own modification time - which only updates when files are added, removed, or renamed directly within that directory. Modifying a file inside a subdirectory does not change the parent directory's timestamp.
+
+With `--recursive-mtime` enabled, weblist calculates directory modification time by scanning all nested files and using the newest file's timestamp. This is useful when you want directories sorted by when their content was last updated, regardless of nesting depth.
+
+```bash
+# Enable recursive modification time calculation
+weblist --recursive-mtime
+```
+
+**Tradeoff:** This feature walks the entire directory tree to find the newest file, which can be slow on large directory structures with many nested files. Use with caution on directories containing thousands of files.
 
 ## Custom Branding
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type options struct {
 	CustomFooter             string `long:"custom-footer" env:"CUSTOM_FOOTER" description:"custom footer text (can contain HTML)"`
 	EnableSyntaxHighlighting bool   `long:"syntax-highlight" env:"SYNTAX_HIGHLIGHT" description:"enable syntax highlighting"`
 	EnableMultiSelect        bool   `long:"multi" env:"MULTI_SELECT" description:"enable multi-file selection and download"`
+	RecursiveMtime           bool   `long:"recursive-mtime" env:"RECURSIVE_MTIME" description:"directory mtime from newest file"`
 
 	InsecureCookies bool          `long:"insecure-cookies" env:"INSECURE_COOKIES" description:"allow cookies without secure flag"`
 	SessionTTL      time.Duration `long:"session-ttl" env:"SESSION_TTL" default:"24h" description:"session timeout"`
@@ -125,6 +126,7 @@ func runServer(ctx context.Context, opts *options) error {
 		InsecureCookies:          opts.InsecureCookies,
 		SessionTTL:               opts.SessionTTL,
 		EnableMultiSelect:        opts.EnableMultiSelect,
+		RecursiveMtime:           opts.RecursiveMtime,
 	}
 
 	// create HTTP server


### PR DESCRIPTION
**Summary**

Adds `--recursive-mtime` CLI flag that calculates directory modification time by scanning all nested files and using the newest timestamp.

**Default behavior**: Directory mtime only updates when files are added, removed, or renamed directly within that directory. Modifying a file inside a subdirectory does not change the parent directory timestamp.

**With --recursive-mtime**: Weblist walks the entire directory tree to find the newest file and uses that timestamp for the directory. This is useful when sorting directories by when their content was last updated, regardless of nesting depth.

**Changes**
- Add `--recursive-mtime` CLI flag (env: `RECURSIVE_MTIME`)
- Implement `getRecursiveMtime()` helper using `fs.WalkDir`
- Apply recursive mtime to directories in `getFileList` when enabled
- Add tests for recursive mtime calculation
- Document feature in README with performance tradeoff warning

*Note: This feature can be slow on large directory structures since it walks all nested files.*