### PR TITLE
Add shell completions for bash, zsh, and fish

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - completions/*
     rlcp: true
 
 brews:
@@ -57,6 +58,10 @@ brews:
     homepage: "https://weblist.umputun.dev"
     description: "weblist is a self-hosted web service to access local files and folders"
     license: "MIT"
+    extra_install: |
+      bash_completion.install "completions/weblist.bash" => "weblist"
+      zsh_completion.install "completions/weblist.zsh" => "_weblist"
+      fish_completion.install "completions/weblist.fish" => "weblist.fish"
 
 nfpms:
   - id: weblist
@@ -74,3 +79,10 @@ nfpms:
     bindir: /usr/bin
     epoch: 1
     release: 1
+    contents:
+      - src: completions/weblist.bash
+        dst: /usr/share/bash-completion/completions/weblist
+      - src: completions/weblist.zsh
+        dst: /usr/share/zsh/vendor-completions/_weblist
+      - src: completions/weblist.fish
+        dst: /usr/share/fish/vendor_completions.d/weblist.fish

--- a/completions/weblist.bash
+++ b/completions/weblist.bash
@@ -1,8 +1,7 @@
 # bash completion for weblist (generated via go-flags)
 _weblist() {
     local args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
-    local IFS=$'\n'
-    COMPREPLY=($(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null))
+    mapfile -t COMPREPLY < <(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null)
     return 0
 }
 complete -o default -F _weblist weblist

--- a/completions/weblist.bash
+++ b/completions/weblist.bash
@@ -1,0 +1,8 @@
+# bash completion for weblist (generated via go-flags)
+_weblist() {
+    local args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+    local IFS=$'\n'
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null))
+    return 0
+}
+complete -o default -F _weblist weblist

--- a/completions/weblist.fish
+++ b/completions/weblist.fish
@@ -1,2 +1,2 @@
 # fish completion for weblist (generated via go-flags)
-complete -c weblist -a '(GO_FLAGS_COMPLETION=1 weblist (commandline -cop) 2>/dev/null)'
+complete -c weblist -a '(GO_FLAGS_COMPLETION=verbose weblist (commandline -cop) 2>/dev/null | string replace -r "\\s+# " "\t")'

--- a/completions/weblist.fish
+++ b/completions/weblist.fish
@@ -1,0 +1,2 @@
+# fish completion for weblist (generated via go-flags)
+complete -c weblist -a '(GO_FLAGS_COMPLETION=1 weblist (commandline -cop) 2>/dev/null)'

--- a/completions/weblist.zsh
+++ b/completions/weblist.zsh
@@ -2,11 +2,24 @@
 
 # zsh completion for weblist (generated via go-flags)
 _weblist() {
-    local IFS=$'\n'
-    local -a completions
-    completions=($(GO_FLAGS_COMPLETION=1 "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null))
-    if (( ${#completions} )); then
-        compadd -- "${completions[@]}"
+    local -a lines
+    lines=(${(f)"$(GO_FLAGS_COMPLETION=verbose "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null)"})
+    if (( ${#lines} )); then
+        local -a descr
+        local line item desc
+        for line in "${lines[@]}"; do
+            if [[ "$line" = *'  # '* ]]; then
+                item="${line%%  *}"
+                desc="${line#*  \# }"
+                descr+=("${item//:/\\:}:${desc}")
+            else
+                item="${line%%  *}"
+                [[ -z "$item" ]] && item="$line"
+                [[ "$item" = *" "* ]] && continue
+                descr+=("${item//:/\\:}")
+            fi
+        done
+        _describe 'command' descr
     else
         _files
     fi

--- a/completions/weblist.zsh
+++ b/completions/weblist.zsh
@@ -1,0 +1,15 @@
+#compdef weblist
+
+# zsh completion for weblist (generated via go-flags)
+_weblist() {
+    local IFS=$'\n'
+    local -a completions
+    completions=($(GO_FLAGS_COMPLETION=1 "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null))
+    if (( ${#completions} )); then
+        compadd -- "${completions[@]}"
+    else
+        _files
+    fi
+}
+
+_weblist "$@"

--- a/main.go
+++ b/main.go
@@ -63,7 +63,9 @@ type options struct {
 var opts options
 
 func main() {
-	fmt.Printf("weblist %s\n", versionInfo())
+	if os.Getenv("GO_FLAGS_COMPLETION") == "" {
+		fmt.Printf("weblist %s\n", versionInfo())
+	}
 	p := flags.NewParser(&opts, flags.PrintErrors|flags.PassDoubleDash|flags.HelpFlag)
 	if _, err := p.Parse(); err != nil {
 		if !errors.Is(err.(*flags.Error).Type, flags.ErrHelp) {


### PR DESCRIPTION
## Summary

- Add completion wrapper scripts for bash, zsh, and fish that use go-flags' built-in `GO_FLAGS_COMPLETION` mechanism
- Update `.goreleaser.yml` to include completions in release archives, Homebrew formula (`extra_install`), and deb/rpm packages (`contents`)
- Suppress version banner when running in completion mode to avoid polluting output

After this, `brew install umputun/apps/weblist` will automatically install shell completions.