### PR TITLE
harden docker workflow against CI injection attacks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,10 +5,15 @@ on:
     workflows: [build-app]
     types: [completed]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
       (github.event.workflow_run.head_branch == 'master' ||
        startsWith(github.event.workflow_run.head_branch, 'v') ||
        github.actor == 'umputun')
@@ -140,8 +145,10 @@ jobs:
 
       - name: determine tags
         id: tags
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          branch="${{ github.event.workflow_run.head_branch }}"
+          branch="${HEAD_BRANCH}"
           branch="${branch//\//_}"  # replace / with _ for valid docker tags
           echo "branch=${branch}" >> $GITHUB_OUTPUT
           if [[ "$branch" == v* ]]; then

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -159,11 +159,12 @@ jobs:
 
       - name: create ghcr.io manifest and push
         working-directory: /tmp/digests/ghcr
+        env:
+          BRANCH: ${{ steps.tags.outputs.branch }}
+          IS_TAG: ${{ steps.tags.outputs.is_tag }}
         run: |
-          branch="${{ steps.tags.outputs.branch }}"
-          is_tag="${{ steps.tags.outputs.is_tag }}"
-          tags="-t ghcr.io/${{ github.actor }}/weblist:${branch}"
-          if [[ "$is_tag" == "true" ]]; then
+          tags="-t ghcr.io/${{ github.actor }}/weblist:${BRANCH}"
+          if [[ "$IS_TAG" == "true" ]]; then
             tags="${tags} -t ghcr.io/${{ github.actor }}/weblist:latest"
           fi
           docker buildx imagetools create ${tags} \
@@ -171,11 +172,12 @@ jobs:
 
       - name: create dockerhub manifest and push
         working-directory: /tmp/digests/dockerhub
+        env:
+          BRANCH: ${{ steps.tags.outputs.branch }}
+          IS_TAG: ${{ steps.tags.outputs.is_tag }}
         run: |
-          branch="${{ steps.tags.outputs.branch }}"
-          is_tag="${{ steps.tags.outputs.is_tag }}"
-          tags="-t ${{ github.actor }}/weblist:${branch}"
-          if [[ "$is_tag" == "true" ]]; then
+          tags="-t ${{ github.actor }}/weblist:${BRANCH}"
+          if [[ "$IS_TAG" == "true" ]]; then
             tags="${tags} -t ${{ github.actor }}/weblist:latest"
           fi
           docker buildx imagetools create ${tags} \


### PR DESCRIPTION
## Summary
- add top-level `permissions: contents: read, packages: write` (least privilege)
- add `github.event.workflow_run.event == 'push'` guard to prevent Docker builds from firing on PR-triggered CI completions
- replace direct `${{ github.event.workflow_run.head_branch }}` interpolation in `run:` blocks with `env:` variable mapping to prevent shell injection via attacker-controlled branch names

Context: https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation