### PR TITLE
ci: harden workflows, add fetch-depth: 0 for goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
       - "updater/**"
       - "**.md"
 
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -28,6 +30,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: build and test
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
     workflows: [build-app]
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: >-
@@ -28,26 +31,27 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: login to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.PKG_TOKEN }}
 
       - name: login to dockerhub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: build and push to ghcr.io by digest
         id: build-ghcr
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -59,7 +63,7 @@ jobs:
 
       - name: build and push to dockerhub by digest
         id: build-dockerhub
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -78,14 +82,14 @@ jobs:
           touch "/tmp/digests/dockerhub/${digest_dockerhub#sha256:}"
 
       - name: upload ghcr digest
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: digests-ghcr-${{ matrix.artifact }}
           path: /tmp/digests/ghcr/*
           retention-days: 1
 
       - name: upload dockerhub digest
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: digests-dockerhub-${{ matrix.artifact }}
           path: /tmp/digests/dockerhub/*
@@ -96,14 +100,14 @@ jobs:
     needs: build
     steps:
       - name: download ghcr digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests/ghcr
           pattern: digests-ghcr-*
           merge-multiple: true
 
       - name: download dockerhub digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests/dockerhub
           pattern: digests-dockerhub-*
@@ -123,17 +127,17 @@ jobs:
           echo "All $expected digests present for both registries"
 
       - name: set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: login to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.PKG_TOKEN }}
 
       - name: login to dockerhub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,9 @@ on:
     paths_ignored:
       - "**.md"
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     name: e2e
@@ -23,6 +26,8 @@ jobs:
 
     - name: check out code
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: cache playwright browsers
       uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,18 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: check out code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: set up go
         uses: actions/setup-go@v6
@@ -18,7 +24,7 @@ jobs:
           go-version: "1.26"
 
       - name: run goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: ~> 1.25
           args: release --clean


### PR DESCRIPTION
## Changes

**release.yml:**
- Add `fetch-depth: 0` to checkout — goreleaser needs full git history for changelog generation and tag resolution (see https://goreleaser.com/ci/actions/)
- Upgrade `goreleaser/goreleaser-action` v6 → v7
- Add `permissions: contents: write` (required for creating releases)
- Add `persist-credentials: false` to checkout

**docker.yml:**
- Upgrade `docker/setup-buildx-action` v3 → v4
- Upgrade `docker/login-action` v3 → v4
- Upgrade `docker/build-push-action` v6 → v7
- Upgrade `actions/upload-artifact` v6 → v7
- Upgrade `actions/download-artifact` v7 → v8
- Add `permissions: contents: read`
- Add `persist-credentials: false` to checkout

**ci.yml:**
- Add `permissions: contents: read`
- Add `persist-credentials: false` to checkout

**e2e.yml:**
- Add `permissions: contents: read`
- Add `persist-credentials: false` to checkout