### PR TITLE
Replace hand-rolled CSRF tokens with http.CrossOriginProtection

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -773,9 +773,7 @@ func TestIntegrationWithAuth(t *testing.T) {
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		// check login page content
 		assert.Contains(t, string(body), "<h3>Login</h3>")
-		assert.Contains(t, string(body), "csrf_token")
 		assert.Contains(t, string(body), "password")
 	})
 
@@ -807,31 +805,15 @@ func TestIntegrationWithAuth(t *testing.T) {
 			},
 		}
 
-		// first get the login page to extract the CSRF token
-		resp, err := failedLoginClient.Get(baseURL + "/login")
-		require.NoError(t, err)
-		resp.Body.Close()
-
-		// find the CSRF token in cookies
-		csrfCookie := ""
-		for _, cookie := range jar.Cookies(resp.Request.URL) {
-			if cookie.Name == "csrf_token" {
-				csrfCookie = cookie.Value
-				break
-			}
-		}
-		require.NotEmpty(t, csrfCookie, "CSRF cookie should be set")
-
-		// POST the login form with invalid credentials
-		formValues := fmt.Sprintf("username=%s&password=%s&csrf_token=%s",
-			testUser, "wrong-form-password", csrfCookie)
+		formValues := fmt.Sprintf("username=%s&password=%s",
+			testUser, "wrong-form-password")
 
 		req, err := http.NewRequest("POST", baseURL+"/login",
 			strings.NewReader(formValues))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-		resp, err = failedLoginClient.Do(req)
+		resp, err := failedLoginClient.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -876,32 +858,15 @@ func TestIntegrationWithAuth(t *testing.T) {
 			},
 		}
 
-		// first get the login page to extract the CSRF token
-		resp, err := formLoginClient.Get(baseURL + "/login")
-		require.NoError(t, err)
-		// no need to read the body here, we only need the cookie
-		resp.Body.Close()
-
-		// find the CSRF token in cookies
-		csrfCookie := ""
-		for _, cookie := range jar.Cookies(resp.Request.URL) {
-			if cookie.Name == "csrf_token" {
-				csrfCookie = cookie.Value
-				break
-			}
-		}
-		require.NotEmpty(t, csrfCookie, "CSRF cookie should be set")
-
-		// POST the login form with valid credentials
-		formValues := fmt.Sprintf("username=%s&password=%s&csrf_token=%s",
-			testUser, testPassword, csrfCookie)
+		formValues := fmt.Sprintf("username=%s&password=%s",
+			testUser, testPassword)
 
 		req, err := http.NewRequest("POST", baseURL+"/login",
 			strings.NewReader(formValues))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-		resp, err = formLoginClient.Do(req)
+		resp, err := formLoginClient.Do(req)
 		require.NoError(t, err)
 		resp.Body.Close()
 

--- a/server/auth.go
+++ b/server/auth.go
@@ -2,13 +2,10 @@ package server
 
 import (
 	"crypto/hmac"
-	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
-	"io"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -26,35 +23,17 @@ type loginTemplateData struct {
 	BrandName    string
 	BrandColor   string
 	CustomFooter string
-	CSRFToken    string
 }
 
 // handleLoginPage renders the login page
-func (wb *Web) handleLoginPage(w http.ResponseWriter, r *http.Request) {
-
-	// generate CSRF token
-	csrfToken := wb.generateCSRFToken()
-
-	// set CSRF token in a cookie
-	http.SetCookie(w, &http.Cookie{
-		Name:     "csrf_token",
-		Value:    csrfToken,
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   wb.isRequestSecure(r),
-		SameSite: http.SameSiteStrictMode,
-		MaxAge:   int(5 * time.Minute.Seconds()), // CSRF token valid for 5 minutes
-	})
-
+func (wb *Web) handleLoginPage(w http.ResponseWriter, _ *http.Request) {
 	data := loginTemplateData{
 		Theme:        wb.Theme,
 		HideFooter:   wb.HideFooter,
 		Title:        wb.Title,
 		BrandName:    wb.BrandName,
 		BrandColor:   wb.BrandColor,
-		Error:        "",
 		CustomFooter: wb.CustomFooter,
-		CSRFToken:    csrfToken,
 	}
 
 	if err := wb.templates.loginTemplate.Execute(w, data); err != nil {
@@ -63,45 +42,25 @@ func (wb *Web) handleLoginPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleLoginSubmit handles the login form submission
+// handleLoginSubmit handles the login form submission. CSRF protection is
+// applied at the router level via http.CrossOriginProtection.
 func (wb *Web) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "Failed to parse form", http.StatusBadRequest)
 		return
 	}
 
-	// verify CSRF token
-	formToken := r.FormValue("csrf_token")
-	cookieToken, err := r.Cookie("csrf_token")
-	if err != nil || formToken == "" || subtle.ConstantTimeCompare([]byte(formToken), []byte(cookieToken.Value)) != 1 {
-		wb.renderLoginError(w, r, "Invalid or missing CSRF token")
-		return
-	}
-
 	username := r.FormValue("username")
 	password := r.FormValue("password")
 
-	// check credentials
 	usernameCorrect := subtle.ConstantTimeCompare([]byte(username), []byte(wb.getAuthUser())) == 1
 	passwordCorrect := subtle.ConstantTimeCompare([]byte(password), []byte(wb.Auth)) == 1
 
-	// authentication failed, show error
 	if !usernameCorrect || !passwordCorrect {
-		wb.renderLoginError(w, r, "Invalid username or password")
+		wb.renderLoginError(w, "Invalid username or password")
 		return
 	}
 
-	// clear the CSRF token cookie
-	http.SetCookie(w, &http.Cookie{
-		Name:     "csrf_token",
-		Value:    "",
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   wb.isRequestSecure(r),
-		MaxAge:   -1, // delete the cookie
-	})
-
-	// authentication successful, generate session token and set cookie
 	http.SetCookie(w, &http.Cookie{
 		Name:     "auth",
 		Value:    wb.generateSessionToken(),
@@ -112,27 +71,11 @@ func (wb *Web) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   wb.getSessionMaxAge(),
 	})
 
-	// redirect to the home page
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
 // renderLoginError renders the login page with an error message
-func (wb *Web) renderLoginError(w http.ResponseWriter, r *http.Request, errorMsg string) {
-
-	// generate a new CSRF token
-	csrfToken := wb.generateCSRFToken()
-
-	// set CSRF token in cookie
-	http.SetCookie(w, &http.Cookie{
-		Name:     "csrf_token",
-		Value:    csrfToken,
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   wb.isRequestSecure(r),
-		SameSite: http.SameSiteStrictMode,
-		MaxAge:   int(5 * time.Minute.Seconds()),
-	})
-
+func (wb *Web) renderLoginError(w http.ResponseWriter, errorMsg string) {
 	data := loginTemplateData{
 		Theme:        wb.Theme,
 		HideFooter:   wb.HideFooter,
@@ -141,7 +84,6 @@ func (wb *Web) renderLoginError(w http.ResponseWriter, r *http.Request, errorMsg
 		BrandColor:   wb.BrandColor,
 		Error:        errorMsg,
 		CustomFooter: wb.CustomFooter,
-		CSRFToken:    csrfToken,
 	}
 
 	if err := wb.templates.loginTemplate.Execute(w, data); err != nil {
@@ -237,19 +179,6 @@ func (wb *Web) normalizeBrandColor(color string) string {
 	}
 
 	return color
-}
-
-// generateCSRFToken creates a random token for CSRF protection
-func (wb *Web) generateCSRFToken() string {
-	const tokenLength = 32
-	b := make([]byte, tokenLength)
-	_, err := io.ReadFull(rand.Reader, b)
-	if err != nil {
-		// if crypto/rand fails, use uuid which has its own entropy source
-		log.Printf("[WARN] Failed to generate random CSRF token: %v, using UUID fallback", err)
-		return uuid.NewString()
-	}
-	return fmt.Sprintf("%x", b)
 }
 
 // generateSessionToken creates a secure session token based on a random value

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -38,23 +39,15 @@ func TestLoginRateLimit(t *testing.T) {
 
 	// simulate multiple login attempts from the same IP
 	for i := range 10 {
-		// create login form data with incorrect credentials
 		formData := url.Values{}
 		formData.Set("username", "weblist")
 		formData.Set("password", "wrongpassword")
-		formData.Set("csrf_token", "dummy-token") // will fail on CSRF but that's fine for testing rate limit
 
 		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
 		require.NoError(t, err)
 
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.RemoteAddr = "192.168.1.1:1234" // use same IP for all requests
-
-		// add a cookie for CSRF token
-		req.AddCookie(&http.Cookie{
-			Name:  "csrf_token",
-			Value: "dummy-token",
-		})
+		req.RemoteAddr = "192.168.1.1:1234"
 
 		rr := httptest.NewRecorder()
 		router.ServeHTTP(rr, req)
@@ -149,41 +142,18 @@ func TestAuthentication(t *testing.T) {
 	})
 
 	t.Run("access allowed with cookie", func(t *testing.T) {
-		// first we need to login to get a valid token
-		// get CSRF token first
-		loginPageReq, err := http.NewRequest("GET", "/login", nil)
-		require.NoError(t, err)
-		loginPageRR := httptest.NewRecorder()
-		loginHandler := http.HandlerFunc(srv.handleLoginPage)
-		loginHandler.ServeHTTP(loginPageRR, loginPageReq)
-
-		// extract CSRF token
-		cookies := loginPageRR.Result().Cookies()
-		var csrfCookie *http.Cookie
-		for _, cookie := range cookies {
-			if cookie.Name == "csrf_token" {
-				csrfCookie = cookie
-				break
-			}
-		}
-		require.NotNil(t, csrfCookie, "CSRF cookie should be set")
-
-		// submit login
 		formData := url.Values{}
 		formData.Set("username", "weblist")
 		formData.Set("password", "testpassword")
-		formData.Set("csrf_token", csrfCookie.Value)
 		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.AddCookie(csrfCookie)
 
 		rr := httptest.NewRecorder()
 		loginSubmitHandler := http.HandlerFunc(srv.handleLoginSubmit)
 		loginSubmitHandler.ServeHTTP(rr, req)
 
-		// get auth cookie
-		cookies = rr.Result().Cookies()
+		cookies := rr.Result().Cookies()
 		var authCookie *http.Cookie
 		for _, cookie := range cookies {
 			if cookie.Name == "auth" {
@@ -381,46 +351,22 @@ func TestHandleLoginSubmit(t *testing.T) {
 	require.NoError(t, err, "failed to initialize templates")
 
 	t.Run("successful login", func(t *testing.T) {
-		// first get a CSRF token from the login page
-		loginPageReq, err := http.NewRequest("GET", "/login", nil)
-		require.NoError(t, err)
-
-		loginPageRR := httptest.NewRecorder()
-		loginHandler := http.HandlerFunc(srv.handleLoginPage)
-		loginHandler.ServeHTTP(loginPageRR, loginPageReq)
-
-		// extract CSRF token cookie
-		cookies := loginPageRR.Result().Cookies()
-		var csrfCookie *http.Cookie
-		for _, cookie := range cookies {
-			if cookie.Name == "csrf_token" {
-				csrfCookie = cookie
-				break
-			}
-		}
-		require.NotNil(t, csrfCookie, "CSRF cookie should be set")
-
-		// create a form data with correct credentials
 		formData := url.Values{}
 		formData.Set("username", "weblist")
 		formData.Set("password", "testpassword")
-		formData.Set("csrf_token", csrfCookie.Value)
 
 		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.AddCookie(csrfCookie) // add the CSRF cookie to the request
 
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(srv.handleLoginSubmit)
 		handler.ServeHTTP(rr, req)
 
-		// check redirect on successful login
 		assert.Equal(t, http.StatusSeeOther, rr.Code)
 		assert.Equal(t, "/", rr.Header().Get("Location"))
 
-		// check that auth cookie was set
-		cookies = rr.Result().Cookies()
+		cookies := rr.Result().Cookies()
 		var authCookie *http.Cookie
 		for _, cookie := range cookies {
 			if cookie.Name == "auth" {
@@ -429,90 +375,44 @@ func TestHandleLoginSubmit(t *testing.T) {
 			}
 		}
 		require.NotNil(t, authCookie, "Auth cookie should be set")
-		// verify the session token is valid using our validation function
 		assert.True(t, srv.validateSessionToken(authCookie.Value), "Session token should be valid")
 	})
 
 	t.Run("failed login - wrong username", func(t *testing.T) {
-		// first get a CSRF token from the login page
-		loginPageReq, err := http.NewRequest("GET", "/login", nil)
-		require.NoError(t, err)
-
-		loginPageRR := httptest.NewRecorder()
-		loginHandler := http.HandlerFunc(srv.handleLoginPage)
-		loginHandler.ServeHTTP(loginPageRR, loginPageReq)
-
-		// extract CSRF token cookie
-		cookies := loginPageRR.Result().Cookies()
-		var csrfCookie *http.Cookie
-		for _, cookie := range cookies {
-			if cookie.Name == "csrf_token" {
-				csrfCookie = cookie
-				break
-			}
-		}
-		require.NotNil(t, csrfCookie, "CSRF cookie should be set")
-
 		formData := url.Values{}
 		formData.Set("username", "wronguser")
 		formData.Set("password", "testpassword")
-		formData.Set("csrf_token", csrfCookie.Value)
 
 		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.AddCookie(csrfCookie) // add the CSRF cookie to the request
 
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(srv.handleLoginSubmit)
 		handler.ServeHTTP(rr, req)
 
-		// should render login page with error
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.Contains(t, rr.Body.String(), "Invalid username or password")
 	})
 
 	t.Run("failed login - wrong password", func(t *testing.T) {
-		// first get a CSRF token from the login page
-		loginPageReq, err := http.NewRequest("GET", "/login", nil)
-		require.NoError(t, err)
-
-		loginPageRR := httptest.NewRecorder()
-		loginHandler := http.HandlerFunc(srv.handleLoginPage)
-		loginHandler.ServeHTTP(loginPageRR, loginPageReq)
-
-		// extract CSRF token cookie
-		cookies := loginPageRR.Result().Cookies()
-		var csrfCookie *http.Cookie
-		for _, cookie := range cookies {
-			if cookie.Name == "csrf_token" {
-				csrfCookie = cookie
-				break
-			}
-		}
-		require.NotNil(t, csrfCookie, "CSRF cookie should be set")
-
 		formData := url.Values{}
 		formData.Set("username", "weblist")
 		formData.Set("password", "wrongpassword")
-		formData.Set("csrf_token", csrfCookie.Value)
 
 		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.AddCookie(csrfCookie) // add the CSRF cookie to the request
 
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(srv.handleLoginSubmit)
 		handler.ServeHTTP(rr, req)
 
-		// should render login page with error
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.Contains(t, rr.Body.String(), "Invalid username or password")
 	})
 
 	t.Run("form parsing error", func(t *testing.T) {
-		// create a malformed request body to trigger ParseForm error
 		req, err := http.NewRequest("POST", "/login", strings.NewReader("%"))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -526,63 +426,6 @@ func TestHandleLoginSubmit(t *testing.T) {
 		assert.Contains(t, rr.Body.String(), "Failed to parse form")
 	})
 
-	t.Run("missing CSRF token", func(t *testing.T) {
-		formData := url.Values{}
-		formData.Set("username", "weblist")
-		formData.Set("password", "testpassword")
-		// deliberately missing CSRF token
-
-		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-		rr := httptest.NewRecorder()
-		handler := http.HandlerFunc(srv.handleLoginSubmit)
-		handler.ServeHTTP(rr, req)
-
-		// should render login page with CSRF error
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Contains(t, rr.Body.String(), "Invalid or missing CSRF token")
-	})
-
-	t.Run("invalid CSRF token", func(t *testing.T) {
-		// first get a CSRF token from the login page
-		loginPageReq, err := http.NewRequest("GET", "/login", nil)
-		require.NoError(t, err)
-
-		loginPageRR := httptest.NewRecorder()
-		loginHandler := http.HandlerFunc(srv.handleLoginPage)
-		loginHandler.ServeHTTP(loginPageRR, loginPageReq)
-
-		// extract CSRF token cookie
-		cookies := loginPageRR.Result().Cookies()
-		var csrfCookie *http.Cookie
-		for _, cookie := range cookies {
-			if cookie.Name == "csrf_token" {
-				csrfCookie = cookie
-				break
-			}
-		}
-		require.NotNil(t, csrfCookie, "CSRF cookie should be set")
-
-		formData := url.Values{}
-		formData.Set("username", "weblist")
-		formData.Set("password", "testpassword")
-		formData.Set("csrf_token", "invalid-token") // invalid token
-
-		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.AddCookie(csrfCookie) // add the real CSRF cookie
-
-		rr := httptest.NewRecorder()
-		handler := http.HandlerFunc(srv.handleLoginSubmit)
-		handler.ServeHTTP(rr, req)
-
-		// should render login page with CSRF error
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Contains(t, rr.Body.String(), "Invalid or missing CSRF token")
-	})
 }
 
 func TestHandleLoginPage(t *testing.T) {
@@ -630,6 +473,79 @@ func TestNormalizeBrandColor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := srv.normalizeBrandColor(tt.input)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCrossOriginProtection(t *testing.T) {
+	testdataDir, err := filepath.Abs("testdata")
+	require.NoError(t, err)
+
+	srv := &Web{
+		Config: Config{ListenAddr: ":0", Theme: "light", RootDir: testdataDir, Auth: "testpassword", Title: "Test"},
+		FS:     os.DirFS(testdataDir),
+	}
+	router, err := srv.router()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		method         string
+		path           string
+		secFetchSite   string
+		origin         string
+		host           string
+		body           string
+		contentType    string
+		wantForbidden  bool
+		wantStatusZero bool // when not forbidden, we don't care which non-403 code we get
+	}{
+		{name: "GET allowed without headers", method: "GET", path: "/login"},
+		{name: "POST same-origin allowed", method: "POST", path: "/login", secFetchSite: "same-origin",
+			body: "username=weblist&password=wrongpass", contentType: "application/x-www-form-urlencoded"},
+		{name: "POST none allowed (direct nav)", method: "POST", path: "/login", secFetchSite: "none",
+			body: "username=weblist&password=wrongpass", contentType: "application/x-www-form-urlencoded"},
+		{name: "POST cross-site rejected", method: "POST", path: "/login", secFetchSite: "cross-site",
+			body: "username=weblist&password=wrongpass", contentType: "application/x-www-form-urlencoded",
+			wantForbidden: true},
+		{name: "POST same-site rejected (subdomain)", method: "POST", path: "/login", secFetchSite: "same-site",
+			body: "username=weblist&password=wrongpass", contentType: "application/x-www-form-urlencoded",
+			wantForbidden: true},
+		{name: "POST origin matches host allowed", method: "POST", path: "/login",
+			origin: "http://example.com", host: "example.com",
+			body: "username=weblist&password=wrongpass", contentType: "application/x-www-form-urlencoded"},
+		{name: "POST origin mismatch rejected", method: "POST", path: "/login",
+			origin: "http://evil.com", host: "example.com",
+			body: "username=weblist&password=wrongpass", contentType: "application/x-www-form-urlencoded",
+			wantForbidden: true},
+		{name: "POST no headers (non-browser) allowed", method: "POST", path: "/login",
+			body: "username=weblist&password=wrongpass", contentType: "application/x-www-form-urlencoded"},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := strings.NewReader(tt.body)
+			req := httptest.NewRequest(tt.method, tt.path, body)
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+			if tt.secFetchSite != "" {
+				req.Header.Set("Sec-Fetch-Site", tt.secFetchSite)
+			}
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			if tt.host != "" {
+				req.Host = tt.host
+			}
+			// unique source IP per case to avoid /login rate-limiter triggering across cases
+			req.RemoteAddr = fmt.Sprintf("10.0.0.%d:1234", i+1)
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+			if tt.wantForbidden {
+				assert.Equal(t, http.StatusForbidden, rr.Code, "should be rejected as cross-origin")
+				return
+			}
+			assert.NotEqual(t, http.StatusForbidden, rr.Code, "should not be rejected as cross-origin")
 		})
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -213,6 +213,7 @@ func (wb *Web) router() (http.Handler, error) {
 
 	router.Use(rest.Trace, rest.RealIP, rest.Recoverer(lgr.Default()))
 	router.Use(rest.Throttle(1000))
+	router.Use(http.NewCrossOriginProtection().Handler)
 
 	// global rate limiter - 50 requests per second
 	router.Use(tollbooth.HTTPMiddleware(tollbooth.NewLimiter(50, nil)))

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -39,8 +39,7 @@
             
             <form action="/login" method="post">
                 <input type="hidden" name="username" value="weblist">
-                <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}">
-                
+
                 <label for="password" style="width: 100%;">
                     <input type="password" id="password" name="password" placeholder="Enter your password" required autofocus style="width: 100%; box-sizing: border-box;">
                 </label>


### PR DESCRIPTION
Drops the per-request CSRF token cookie + hidden form field in favour of Go 1.25's `http.CrossOriginProtection` middleware (one line in `server/server.go`). The middleware checks the browser-set `Sec-Fetch-Site` header with an `Origin` vs `Host` fallback for older clients, so no client-side instrumentation is needed.

### Why

`Sec-Fetch-Site` is a forbidden header -- the browser sets it and JS cannot forge it. It's been shipped in all major browsers since 2023 (96%+ global coverage per Can I Use), and OWASP elevated it from defence-in-depth to a primary defence in [its CSRF cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html) in December 2025. Compared to the hand-rolled double-submit token it replaces:

- no template instrumentation (`CSRFToken` field, hidden `<input>`)
- no cookie management (`csrf_token` set/clear lifecycle, 5-min TTL)
- no risk of stale-token UX bugs across tabs / back button
- distinguishes _same-origin_ from _same-site_, so subdomain attacks (which `SameSite=Lax` permits) are blocked

### What changed

- `server/server.go` -- `router.Use(http.NewCrossOriginProtection().Handler)` added to the existing middleware chain
- `server/auth.go` -- removed `generateCSRFToken`, `CSRFToken` template field, all `csrf_token` cookie lifecycle code in `handleLoginPage` / `handleLoginSubmit` / `renderLoginError`
- `server/templates/login.html` -- dropped the hidden `csrf_token` input
- `server/auth_test.go` -- new `TestCrossOriginProtection` covering same-origin / cross-site / origin-host-mismatch / non-browser cases; obsolete "missing/invalid CSRF token" subtests removed
- `main_test.go` -- integration tests no longer thread a CSRF token through the login flow

Net: ~190 LoC removed.

### References for context

- [Go 1.25 release notes -- net/http.CrossOriginProtection](https://go.dev/doc/go1.25#nethttppkgnethttp)
- [pkg.go.dev -- http.CrossOriginProtection](https://pkg.go.dev/net/http#CrossOriginProtection)
- Filippo Valsorda, [Cross-Site Request Forgery](https://words.filippo.io/csrf/) -- the research the stdlib middleware is based on
- [Datasette PR #2689](https://github.com/simonw/datasette/pull/2689) -- Simon Willison removed all CSRF tokens from Datasette in April 2026 using the same algorithm
- [OWASP CSRF Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html) -- Fetch Metadata as primary defence

### Notes

- weblist already requires Go 1.26, so the stdlib middleware is available without a backport.
- `SameSite=Lax` on the auth session cookie remains as defence-in-depth.
- For TLS-terminating proxies the middleware compares `Origin` host against `r.Host` (HSTS recommended to prevent HTTP→HTTPS downgrades). The `Sec-Fetch-Site` path is checked first and is unaffected by proxy schemes.