### PR TITLE
fix: refuse symlinks escaping the root, fold case in exclusions

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,10 @@ func runServer(ctx context.Context, opts *options) error {
 	}
 
 	// create OS filesystem locked to the root directory
-	fs := os.DirFS(opts.RootDir)
+	fs, err := newRootFS(opts.RootDir)
+	if err != nil {
+		return fmt.Errorf("failed to create root filesystem: %w", err)
+	}
 
 	// prepare common configuration
 	config := server.Config{

--- a/rootfs.go
+++ b/rootfs.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// rootFS keeps resolved targets inside root; os.DirFS alone allows an in-root symlink to reach outside
+type rootFS struct {
+	root string
+	fsys fs.FS
+}
+
+func newRootFS(root string) (*rootFS, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("get absolute root directory: %w", err)
+	}
+
+	resolvedRoot, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve root directory: %w", err)
+	}
+
+	return &rootFS{root: resolvedRoot, fsys: os.DirFS(resolvedRoot)}, nil
+}
+
+func (r *rootFS) Open(name string) (fs.File, error) {
+	if err := r.validate("open", name); err != nil {
+		return nil, err
+	}
+	return r.fsys.Open(name)
+}
+
+func (r *rootFS) Stat(name string) (fs.FileInfo, error) {
+	if err := r.validate("stat", name); err != nil {
+		return nil, err
+	}
+	return fs.Stat(r.fsys, name)
+}
+
+func (r *rootFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if err := r.validate("readdir", name); err != nil {
+		return nil, err
+	}
+	return fs.ReadDir(r.fsys, name)
+}
+
+func (r *rootFS) validate(op, name string) error {
+	if !fs.ValidPath(name) {
+		return &fs.PathError{Op: op, Path: name, Err: fs.ErrInvalid}
+	}
+
+	resolved, err := filepath.EvalSymlinks(filepath.Join(r.root, filepath.FromSlash(name)))
+	if err != nil {
+		return &fs.PathError{Op: op, Path: name, Err: err}
+	}
+
+	rel, err := filepath.Rel(r.root, resolved)
+	if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return &fs.PathError{Op: op, Path: name, Err: fs.ErrNotExist}
+	}
+
+	// the path can change after evaluation and before the operation. Closing that TOCTOU window
+	// requires descriptor-relative traversal, which would also reject compatible absolute symlinks.
+	return nil
+}

--- a/rootfs_test.go
+++ b/rootfs_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootFSContainsResolvedSymlinks(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "root")
+	rootAlias := filepath.Join(base, "root-alias")
+	outside := filepath.Join(base, "outside")
+	require.NoError(t, os.MkdirAll(filepath.Join(realRoot, "inside"), 0o750))
+	require.NoError(t, os.MkdirAll(outside, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(realRoot, "plain.txt"), []byte("plain"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(realRoot, "inside", "media.txt"), []byte("inside"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("outside"), 0o600))
+	require.NoError(t, os.Symlink(realRoot, rootAlias))
+	require.NoError(t, os.Symlink(filepath.Join(realRoot, "inside"), filepath.Join(realRoot, "absolute-inside")))
+	require.NoError(t, os.Symlink("inside", filepath.Join(realRoot, "relative-inside")))
+	require.NoError(t, os.Symlink(outside, filepath.Join(realRoot, "escape")))
+
+	rootFS, err := newRootFS(rootAlias)
+	require.NoError(t, err)
+	require.Implements(t, (*fs.StatFS)(nil), rootFS)
+	require.Implements(t, (*fs.ReadDirFS)(nil), rootFS)
+
+	openTests := []struct {
+		name string
+		want string
+	}{
+		{name: "plain.txt", want: "plain"},
+		{name: "absolute-inside/media.txt", want: "inside"},
+		{name: "relative-inside/media.txt", want: "inside"},
+	}
+	for _, tt := range openTests {
+		t.Run("opens "+tt.name, func(t *testing.T) {
+			got, readErr := fs.ReadFile(rootFS, tt.name)
+			require.NoError(t, readErr)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+
+	for _, name := range []string{"absolute-inside", "relative-inside"} {
+		t.Run("stats and lists "+name, func(t *testing.T) {
+			info, statErr := fs.Stat(rootFS, name)
+			require.NoError(t, statErr)
+			assert.True(t, info.IsDir())
+
+			entries, readDirErr := fs.ReadDir(rootFS, name)
+			require.NoError(t, readDirErr)
+			require.Len(t, entries, 1)
+			assert.Equal(t, "media.txt", entries[0].Name())
+		})
+	}
+
+	t.Run("rejects an escaping symlink for every filesystem operation", func(t *testing.T) {
+		_, openErr := rootFS.Open("escape/secret.txt")
+		assert.True(t, errors.Is(openErr, fs.ErrNotExist), openErr)
+
+		_, statErr := fs.Stat(rootFS, "escape/secret.txt")
+		assert.True(t, errors.Is(statErr, fs.ErrNotExist), statErr)
+
+		_, readDirErr := fs.ReadDir(rootFS, "escape")
+		assert.True(t, errors.Is(readDirErr, fs.ErrNotExist), readDirErr)
+	})
+}
+
+func TestNewRootFSRejectsMissingRoot(t *testing.T) {
+	_, err := newRootFS(filepath.Join(t.TempDir(), "missing"))
+	assert.Error(t, err)
+}

--- a/server/file_ops.go
+++ b/server/file_ops.go
@@ -332,7 +332,9 @@ func (wb *Web) shouldExclude(path string) bool {
 // "some/.git/config", and "docs/private" excludes "docs/private" along with everything beneath it.
 // Matching works on whole components, so "docs/private" leaves "docs/private2" alone and "vendor"
 // leaves "vendors" alone. All paths are normalized to forward slashes for consistent matching
-// across platforms.
+// across platforms. Comparison is case-insensitive: on case-insensitive filesystems (macOS, Windows)
+// an exact match would let "secret" through when "Secret" is excluded, serving the file the operator
+// meant to hide.
 func matchesExcludes(path string, patterns []string) bool {
 	if len(patterns) == 0 {
 		return false
@@ -342,7 +344,7 @@ func matchesExcludes(path string, patterns []string) bool {
 	pathParts := pathComponents(path)
 	for _, pattern := range patterns {
 		pattern = filepath.ToSlash(pattern)
-		if normalizedPath == pattern {
+		if strings.EqualFold(normalizedPath, pattern) {
 			return true
 		}
 
@@ -351,7 +353,7 @@ func matchesExcludes(path string, patterns []string) bool {
 			continue
 		}
 		for i := 0; i+len(patternParts) <= len(pathParts); i++ {
-			if slices.Equal(pathParts[i:i+len(patternParts)], patternParts) {
+			if slices.EqualFunc(pathParts[i:i+len(patternParts)], patternParts, strings.EqualFold) {
 				return true
 			}
 		}

--- a/server/file_ops_test.go
+++ b/server/file_ops_test.go
@@ -1139,6 +1139,24 @@ func TestShouldExclude(t *testing.T) {
 			exclude:  []string{".git"},
 			expected: true,
 		},
+		{
+			name:     "case-differing component matches, a case-insensitive fs serves it otherwise",
+			path:     "secret/hidden.txt",
+			exclude:  []string{"Secret"},
+			expected: true,
+		},
+		{
+			name:     "case-differing exact path matches",
+			path:     "docs/PRIVATE",
+			exclude:  []string{"docs/private"},
+			expected: true,
+		},
+		{
+			name:     "case folding does not widen matching to partial names",
+			path:     "some/SECRETS/path",
+			exclude:  []string{"Secret"},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Two fixes from reports by @paskal, both reproduced before fixing.

**Symlink escape.** `os.DirFS` only guarantees the paths it opens start with the root, so a symlink placed inside the served directory reached outside it and weblist served the target over both HTTP and SFTP. That contradicts "Locked to the root directory" in the readme and the assumption the SFTP jail makes.

Fixed with a wrapper that resolves the root once at startup and checks every `Open`, `Stat` and `ReadDir` target still resolves inside it. `os.Root` is the obvious tool here and is deliberately not used: it refuses any absolute symlink target, including links that resolve inside the served root, which would 404 every entry in a tree built with absolute symlinks.

**Exclusion case bypass.** On a case-insensitive filesystem `--exclude Secret` left `/secret` and `/SECRET` reachable, serving files the operator meant to hide. Matching now folds case. Both the web listing and the SFTP jail go through `matchesExcludes`, so one change covers both surfaces.

Verified against a built binary, not only unit tests:

```
escape/secret.txt          404   symlink out of the root, refused
link-abs-inside/song.mp3   200   absolute link, target inside root
link-rel-inside/song.mp3   200   relative link inside root
media/song.mp3             200   plain file
Secret/hidden.txt          403
secret/hidden.txt          403   was 200 with content
SECRET/hidden.txt          403   was 200 with content
ok.txt                     200
```

Five listings of a 4000-file directory take 0.06s on master and 0.06s here, so resolving on each operation costs nothing measurable.
