### PR TITLE
fix: contain multi-select checkboxes and honor select-all state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,9 @@
 - On completion, run: formatting, code generation, linting and testing
 - Never commit without running completion sequence
 - Coverage report: `go test -race -coverprofile=coverage.out ./... && go tool cover -func=coverage.out`
-- Normalize code comments: `command -v unfuck-ai-comments >/dev/null || go install github.com/umputun/unfuck-ai-comments@latest; unfuck-ai-comments run --fmt --skip=mocks ./...`
 
 ## Important Workflow Notes
-- Always run tests, linter and normalize comments BEFORE committing anything
+- Always run tests and linter BEFORE committing anything
 - Run tests and linter after making significant changes to verify functionality
 - Don't add "Generated with Claude Code" or "Co-Authored-By: Claude" to commit messages or PRs
 - Do not include "Test plan" sections in PR descriptions

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -61,6 +61,7 @@ func TestMain(m *testing.M) {
 	serverCmd = exec.Command("/tmp/weblist-e2e",
 		"--listen=:18080",
 		"--root="+absTestData,
+		"--multi",
 	)
 	// suppress server output to keep test output clean
 	serverCmd.Stdout = nil
@@ -175,6 +176,22 @@ func TestHome_PageLoads(t *testing.T) {
 	title, err := page.Title()
 	require.NoError(t, err)
 	assert.Contains(t, title, "weblist")
+}
+
+func TestHome_MultiSelectCheckboxIsContained(t *testing.T) {
+	page := newPage(t)
+	_, err := page.Goto(baseURL)
+	require.NoError(t, err)
+
+	checkboxBox, err := page.Locator("#select-all").BoundingBox()
+	require.NoError(t, err)
+	require.NotNil(t, checkboxBox)
+	cellBox, err := page.Locator("th.select-col").BoundingBox()
+	require.NoError(t, err)
+	require.NotNil(t, cellBox)
+
+	assert.InDelta(t, 16, checkboxBox.Width, 0.1)
+	assert.InDelta(t, cellBox.X+(cellBox.Width-checkboxBox.Width)/2, checkboxBox.X, 0.1)
 }
 
 func TestHome_ShowsFiles(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -194,6 +194,30 @@ func TestHome_MultiSelectCheckboxIsContained(t *testing.T) {
 	assert.InDelta(t, cellBox.X+(cellBox.Width-checkboxBox.Width)/2, checkboxBox.X, 0.1)
 }
 
+func TestHome_SelectAllTogglesRowCheckboxes(t *testing.T) {
+	page := newPage(t)
+	_, err := page.Goto(baseURL)
+	require.NoError(t, err)
+
+	total, err := page.Locator(".file-checkbox").Count()
+	require.NoError(t, err)
+	require.NotZero(t, total)
+
+	require.NoError(t, page.Locator("#select-all").Click())
+	waitVisible(t, page.Locator(".selected-count"))
+	_, err = page.WaitForFunction(fmt.Sprintf("document.querySelectorAll('.file-checkbox:checked').length === %d", total), nil)
+	require.NoError(t, err)
+
+	count, err := page.Locator(".selected-count").TextContent()
+	require.NoError(t, err)
+	assert.Contains(t, count, fmt.Sprintf("%d files selected", total))
+
+	require.NoError(t, page.Locator("#select-all").Click())
+	waitHidden(t, page.Locator(".selected-count"))
+	_, err = page.WaitForFunction("document.querySelectorAll('.file-checkbox:checked').length === 0", nil)
+	require.NoError(t, err)
+}
+
 func TestHome_ShowsFiles(t *testing.T) {
 	page := newPage(t)
 	_, err := page.Goto(baseURL)

--- a/server/assets/css/weblist-app.css
+++ b/server/assets/css/weblist-app.css
@@ -17,11 +17,14 @@ table th.select-col, table td.select-cell {
 }
 table th.select-col input[type="checkbox"],
 table td.select-cell input[type="checkbox"] {
+  display: inline-block;
   margin: 0;
+  padding: 0;
   vertical-align: middle;
   position: relative;
   cursor: pointer;
   width: 16px;
+  min-width: 16px;
   height: 16px;
 }
 /* Column widths by class name */

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -393,56 +392,30 @@ func (wb *Web) handleSelectionStatus(w http.ResponseWriter, r *http.Request) {
 
 	// get all selected files from the form
 	selectedFiles := r.Form["selected-files"]
-	selectAll := r.FormValue("select-all")
+	selectAll := r.FormValue("select-all") == "true"
 
-	// toggle logic for select-all
-	var checkState bool
-	if selectAll == "true" {
-		// if select-all is clicked, we need to toggle between selected and unselected
-		// get the total number of files from the form
-		totalFilesStr := r.FormValue("total-files")
-		totalFiles, err := strconv.Atoi(totalFilesStr)
-		if err != nil {
-			http.Error(w, "Invalid total-files value", http.StatusBadRequest)
-			return
-		}
-
-		// check if we're toggling from "all selected" to "none selected" state
-		// if the number of selected files matches the total, we're in "all selected" state
-		if len(selectedFiles) == totalFiles {
-			// toggle to "none selected" state
-			checkState = false
-			selectedFiles = []string{} // clear the selection
-		} else {
-			// otherwise, we're toggling from "none selected" or "partially selected" to "all selected"
-			// get path values for all files in the current directory
+	if selectAll {
+		if r.FormValue("select-all-state") == "true" {
 			selectedFiles = r.Form["path-values"]
-			// set checkboxes to checked state
-			checkState = true
+		} else {
+			selectedFiles = nil
 		}
-	} else {
-		// regular checkbox update - just use the current selection
-		checkState = len(selectedFiles) > 0
 	}
 
 	// prepare template data
 	data := struct {
 		Count         int
 		SelectedFiles []string
-		SelectAll     bool
-		CheckState    bool
 	}{
 		Count:         len(selectedFiles),
 		SelectedFiles: selectedFiles,
-		SelectAll:     selectAll == "true",
-		CheckState:    checkState,
 	}
 
 	// execute the selection-status template
 	w.Header().Set("Content-Type", "text/html")
 	// trigger checkbox sync event when select-all is clicked
-	if selectAll == "true" {
-		w.Header().Set("HX-Trigger", "updateCheckboxes")
+	if selectAll {
+		w.Header().Set("HX-Trigger", "update-checkboxes")
 	}
 	if err := wb.templates.indexTemplate.ExecuteTemplate(w, "selection-status", data); err != nil {
 		http.Error(w, "template rendering error: "+err.Error(), http.StatusInternalServerError)

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -54,6 +54,23 @@ func TestHandleRoot(t *testing.T) {
 	}
 }
 
+func TestHandleRootMultiSelectContract(t *testing.T) {
+	srv := setupTestServer(t)
+	srv.EnableMultiSelect = true
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	srv.handleRoot(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, "hx-on:update-checkboxes=")
+	assert.NotContains(t, body, "hx-on:updateCheckboxes=")
+	assert.Contains(t, body, `<input type="checkbox" id="select-all" name="select-all-state" value="true"`)
+	assert.Contains(t, body, `hx-vals='{"select-all": "true"}'`)
+	assert.NotContains(t, body, "total-files")
+}
+
 func TestHandleDownload(t *testing.T) {
 	srv := setupTestServer(t)
 
@@ -1004,23 +1021,12 @@ func TestHandleSelectionStatus(t *testing.T) {
 		assert.Empty(t, rr.Header().Get("HX-Trigger"))
 	})
 
-	t.Run("select-all with invalid total-files", func(t *testing.T) {
+	t.Run("checked select-all selects every path", func(t *testing.T) {
 		formData := url.Values{}
 		formData.Set("select-all", "true")
-		formData.Set("total-files", "invalid")
-		req := httptest.NewRequest("POST", "/partials/selection-status", strings.NewReader(formData.Encode()))
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		rr := httptest.NewRecorder()
-
-		web.handleSelectionStatus(rr, req)
-		require.Equal(t, http.StatusBadRequest, rr.Code)
-		require.Contains(t, rr.Body.String(), "Invalid total-files value")
-	})
-
-	t.Run("select-all toggles from none to all", func(t *testing.T) {
-		formData := url.Values{}
-		formData.Set("select-all", "true")
-		formData.Set("total-files", "3")
+		formData.Set("select-all-state", "true")
+		formData.Add("selected-files", "file1.txt")
+		formData.Add("selected-files", "file2.txt")
 		formData.Add("path-values", "file1.txt")
 		formData.Add("path-values", "file2.txt")
 		formData.Add("path-values", "file3.txt")
@@ -1030,25 +1036,44 @@ func TestHandleSelectionStatus(t *testing.T) {
 
 		web.handleSelectionStatus(rr, req)
 		require.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, "updateCheckboxes", rr.Header().Get("HX-Trigger"))
+		assert.Equal(t, "update-checkboxes", rr.Header().Get("HX-Trigger"))
 		require.Contains(t, rr.Body.String(), "3 files selected")
 	})
 
-	t.Run("select-all toggles from all to none", func(t *testing.T) {
+	t.Run("checked select-all handles a non-selectable parent row", func(t *testing.T) {
+		listingEntries := []string{"..", "file1.txt", "file2.txt"}
 		formData := url.Values{}
 		formData.Set("select-all", "true")
-		formData.Set("total-files", "2")
-		formData.Add("selected-files", "file1.txt")
-		formData.Add("selected-files", "file2.txt")
-		formData.Add("path-values", "file1.txt")
-		formData.Add("path-values", "file2.txt")
+		formData.Set("select-all-state", "true")
+		for _, path := range listingEntries[1:] {
+			formData.Add("path-values", path)
+		}
 		req := httptest.NewRequest("POST", "/partials/selection-status", strings.NewReader(formData.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		rr := httptest.NewRecorder()
 
 		web.handleSelectionStatus(rr, req)
 		require.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, "updateCheckboxes", rr.Header().Get("HX-Trigger"))
+		assert.Equal(t, "update-checkboxes", rr.Header().Get("HX-Trigger"))
+		require.Contains(t, rr.Body.String(), "2 files selected")
+		require.NotContains(t, rr.Body.String(), `value=".."`)
+	})
+
+	t.Run("unchecked select-all clears a partial selection", func(t *testing.T) {
+		formData := url.Values{}
+		formData.Set("select-all", "true")
+		formData.Add("selected-files", "file1.txt")
+		formData.Add("selected-files", "file2.txt")
+		formData.Add("path-values", "file1.txt")
+		formData.Add("path-values", "file2.txt")
+		formData.Add("path-values", "file3.txt")
+		req := httptest.NewRequest("POST", "/partials/selection-status", strings.NewReader(formData.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+
+		web.handleSelectionStatus(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "update-checkboxes", rr.Header().Get("HX-Trigger"))
 		require.NotContains(t, rr.Body.String(), "files selected")
 	})
 }

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -11,7 +11,7 @@
     <script src="/assets/js/htmx.min.js"></script>
 </head>
 <body hx-on:keydown="if(event.key === 'Escape') { document.body.style.overflow = ''; document.getElementById('modal-container').innerHTML = ''; }"
-      hx-on:updateCheckboxes="document.querySelectorAll('.file-checkbox').forEach(function(cb) { cb.checked = document.getElementById('select-all').checked; })">
+      hx-on:update-checkboxes="document.querySelectorAll('.file-checkbox').forEach(function(cb) { cb.checked = document.getElementById('select-all').checked; })">
 <div id="htmx-error" class="htmx-error-container"></div>
 <script>
 document.body.addEventListener('htmx:responseError', function(evt) {
@@ -142,12 +142,12 @@ document.body.addEventListener('htmx:afterSwap', function(evt) {
         <tr>
             {{ if .EnableMultiSelect }}
             <th class="select-col">
-                <input type="checkbox" id="select-all" title="Select all files" 
+                <input type="checkbox" id="select-all" name="select-all-state" value="true" title="Select all files"
                        hx-post="/partials/selection-status"
                        hx-trigger="click"
                        hx-target="#selection-status"
                        hx-include=".file-checkbox, .path-value"
-                       hx-vals='{"select-all": "true", "total-files": "{{ len .Files }}"}'
+                       hx-vals='{"select-all": "true"}'
                        hx-swap="innerHTML">
             </th>
             {{ end }}


### PR DESCRIPTION
fixes the two multi-select bugs in #53 and #54. Both reproduce in Firefox and Chromium on v0.20.3, so neither is Firefox-specific.

### Checkbox layout (#53)

`custom.css` applies form-input defaults that include `display: block` and `min-width: 300px`, which the login form depends on. The multi-select rule only set `width: 16px`, so `min-width` won and every checkbox overflowed its 40px cell into the file-name column.

the scoped checkbox rule now resets `display`, `min-width` and `padding`. Login styling is untouched.

### Select all (#54)

the checkbox sync handler never ran. The HTML parser lowercased `hx-on:updateCheckboxes` to `hx-on:updatecheckboxes`, while the server emitted `updateCheckboxes`. Both now use `update-checkboxes`.

the handler also inferred the requested state by comparing the submitted selection count against `total-files`. That could never clear a subdirectory, because `len .Files` includes the `..` row while the submitted checkboxes exclude it, so the counts never match. It also re-selected everything when the user cleared one row by hand and then clicked the still-checked header to clear the rest.

the header now submits `select-all-state=true` only while it is checked, and the handler follows that state directly. The count inference and the `total-files` parameter are gone.

regression coverage is checkbox geometry and a real select/clear flow through HTMX, plus handler cases for a non-selectable parent row and a partial selection. Checked by hand in Firefox 144 and Chromium 141, at the root and in a subdirectory, and across widths from 1200px down to 480px. The reports are from Firefox 154.

separately, `CLAUDE.md` drops the obsolete `unfuck-ai-comments` completion step.

Fix #53, fix #54
