### PR TITLE
fix(auth): make browser login password-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ weblist [options]
 - `-e, --exclude`: Files and directories to exclude (can be repeated) - env: `EXCLUDE`
 - `-f, --hide-footer`: Hide footer - env: `HIDE_FOOTER`
 - `-a, --auth`: Enable authentication with the specified password - env: `AUTH`
-- `--auth-user`: Username for authentication (default: `weblist`) - env: `AUTH_USER`
+- `--auth-user`: Username for HTTP Basic Auth (default: `weblist`) - env: `AUTH_USER`
 - `--session-secret`: Secret key for session tokens (auto-generated if not set) - env: `SESSION_SECRET`
 - `--session-ttl`: Session timeout duration (default: `24h`) - env: `SESSION_TTL`
 - `--insecure-cookies`: Allow cookies without secure flag - env: `INSECURE_COOKIES`
@@ -158,7 +158,7 @@ Weblist provides optional password protection for your file listings:
 # Enable authentication with a password
 weblist --auth your_password
 
-# Customize the username (default is "weblist")
+# Customize the HTTP Basic Auth username (default is "weblist")
 weblist --auth your_password --auth-user admin
 
 # Set a specific session secret key
@@ -172,8 +172,8 @@ weblist --auth your_password --insecure-cookies
 ```
 
 When authentication is enabled:
-- Users will be prompted with a login screen
-- The username is customizable via the `--auth-user` parameter (defaults to "weblist")
+- Browser login uses a password-only form
+- The HTTP Basic Auth username is customizable via `--auth-user` (defaults to "weblist")
 - The password is whatever you specify with the `--auth` parameter
 - Sessions are secured with HMAC-SHA256 signed tokens
 - Session secrets are automatically generated if not explicitly provided
@@ -429,7 +429,7 @@ services:
       - ROOT_DIR=/data
       - EXCLUDE=.git,.env
       - AUTH=your_password  # Optional: Enable password authentication
-      - AUTH_USER=admin  # Optional: Custom username for authentication (default: weblist)
+      - AUTH_USER=admin  # Optional: HTTP Basic Auth username (default: weblist)
       - SESSION_SECRET=your_secure_key  # Optional: Secret for signing session tokens
       - SESSION_TTL=24h  # Optional: Session timeout duration
       - BRAND_NAME=My Company  # Optional: Display company name in navbar

--- a/e2e/auth_test.go
+++ b/e2e/auth_test.go
@@ -33,6 +33,7 @@ func startAuthServer(t *testing.T) func() {
 		"--listen=:18081",
 		"--root="+absTestData,
 		"--auth="+testPassword,
+		"--auth-user=customuser",
 		"--insecure-cookies", // needed for http in tests
 	)
 	cmd.Stdout = nil
@@ -65,7 +66,7 @@ func TestAuth_LoginPageShown(t *testing.T) {
 	// should redirect to login page
 	require.NoError(t, page.WaitForURL("**/login"))
 
-	// check login form is visible - note: username is hidden, only password is visible
+	// check password-only login form is visible
 	visible, err := page.Locator("input[name='password']").IsVisible()
 	require.NoError(t, err)
 	assert.True(t, visible, "password input should be visible")
@@ -74,10 +75,9 @@ func TestAuth_LoginPageShown(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, visible, "submit button should be visible")
 
-	// verify hidden username field exists with value "weblist"
-	usernameValue, err := page.Locator("input[name='username']").GetAttribute("value")
+	usernameCount, err := page.Locator("input[name='username']").Count()
 	require.NoError(t, err)
-	assert.Equal(t, "weblist", usernameValue)
+	assert.Zero(t, usernameCount, "username input should not exist")
 }
 
 func TestAuth_LoginValid(t *testing.T) {
@@ -88,10 +88,10 @@ func TestAuth_LoginValid(t *testing.T) {
 	_, err := page.Goto(authBaseURL + "/login")
 	require.NoError(t, err)
 
-	// wait for login form - only password field is visible
+	// wait for password-only login form
 	waitVisible(t, page.Locator("input[name='password']"))
 
-	// fill in password (username is pre-filled as hidden field)
+	// fill in password
 	require.NoError(t, page.Locator("input[name='password']").Fill(testPassword))
 
 	// submit form

--- a/main_test.go
+++ b/main_test.go
@@ -695,7 +695,7 @@ func TestIntegrationWithAuth(t *testing.T) {
 
 	// test password and credentials
 	testPassword := "test-password"
-	testUser := "weblist"
+	testUser := "testuser"
 
 	// set up options for the server with authentication
 	opts = options{
@@ -805,8 +805,7 @@ func TestIntegrationWithAuth(t *testing.T) {
 			},
 		}
 
-		formValues := fmt.Sprintf("username=%s&password=%s",
-			testUser, "wrong-form-password")
+		formValues := "password=wrong-form-password"
 
 		req, err := http.NewRequest("POST", baseURL+"/login",
 			strings.NewReader(formValues))
@@ -823,7 +822,7 @@ func TestIntegrationWithAuth(t *testing.T) {
 		// check the response contains error message
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		assert.Contains(t, string(body), "Invalid username or password")
+		assert.Contains(t, string(body), "Invalid password")
 
 		// verify no auth cookie is set after failed login
 		authCookieFound := false
@@ -858,8 +857,7 @@ func TestIntegrationWithAuth(t *testing.T) {
 			},
 		}
 
-		formValues := fmt.Sprintf("username=%s&password=%s",
-			testUser, testPassword)
+		formValues := "password=" + testPassword
 
 		req, err := http.NewRequest("POST", baseURL+"/login",
 			strings.NewReader(formValues))

--- a/server/auth.go
+++ b/server/auth.go
@@ -50,14 +50,12 @@ func (wb *Web) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	username := r.FormValue("username")
 	password := r.FormValue("password")
 
-	usernameCorrect := subtle.ConstantTimeCompare([]byte(username), []byte(wb.getAuthUser())) == 1
 	passwordCorrect := subtle.ConstantTimeCompare([]byte(password), []byte(wb.Auth)) == 1
 
-	if !usernameCorrect || !passwordCorrect {
-		wb.renderLoginError(w, "Invalid username or password")
+	if !passwordCorrect {
+		wb.renderLoginError(w, "Invalid password")
 		return
 	}
 

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -143,7 +143,6 @@ func TestAuthentication(t *testing.T) {
 
 	t.Run("access allowed with cookie", func(t *testing.T) {
 		formData := url.Values{}
-		formData.Set("username", "weblist")
 		formData.Set("password", "testpassword")
 		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
 		require.NoError(t, err)
@@ -341,6 +340,7 @@ func TestHandleLoginSubmit(t *testing.T) {
 			Theme:      "light",
 			RootDir:    testdataDir,
 			Auth:       "testpassword",
+			AuthUser:   "customuser",
 			Title:      "Test Server",
 		},
 		FS: os.DirFS(testdataDir),
@@ -350,9 +350,8 @@ func TestHandleLoginSubmit(t *testing.T) {
 	err = srv.initTemplates()
 	require.NoError(t, err, "failed to initialize templates")
 
-	t.Run("successful login", func(t *testing.T) {
+	t.Run("password-only login with custom auth user", func(t *testing.T) {
 		formData := url.Values{}
-		formData.Set("username", "weblist")
 		formData.Set("password", "testpassword")
 
 		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
@@ -378,26 +377,39 @@ func TestHandleLoginSubmit(t *testing.T) {
 		assert.True(t, srv.validateSessionToken(authCookie.Value), "Session token should be valid")
 	})
 
-	t.Run("failed login - wrong username", func(t *testing.T) {
-		formData := url.Values{}
-		formData.Set("username", "wronguser")
-		formData.Set("password", "testpassword")
+	t.Run("posted username is ignored", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			username string
+			include  bool
+		}{
+			{name: "absent", include: false},
+			{name: "wrong", username: "wronguser", include: true},
+		}
 
-		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				formData := url.Values{"password": {"testpassword"}}
+				if tt.include {
+					formData.Set("username", tt.username)
+				}
 
-		rr := httptest.NewRecorder()
-		handler := http.HandlerFunc(srv.handleLoginSubmit)
-		handler.ServeHTTP(rr, req)
+				req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
+				require.NoError(t, err)
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Contains(t, rr.Body.String(), "Invalid username or password")
+				rr := httptest.NewRecorder()
+				handler := http.HandlerFunc(srv.handleLoginSubmit)
+				handler.ServeHTTP(rr, req)
+
+				assert.Equal(t, http.StatusSeeOther, rr.Code)
+				assert.Equal(t, "/", rr.Header().Get("Location"))
+			})
+		}
 	})
 
 	t.Run("failed login - wrong password", func(t *testing.T) {
 		formData := url.Values{}
-		formData.Set("username", "weblist")
 		formData.Set("password", "wrongpassword")
 
 		req, err := http.NewRequest("POST", "/login", strings.NewReader(formData.Encode()))
@@ -409,7 +421,7 @@ func TestHandleLoginSubmit(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Contains(t, rr.Body.String(), "Invalid username or password")
+		assert.Contains(t, rr.Body.String(), "Invalid password")
 	})
 
 	t.Run("form parsing error", func(t *testing.T) {
@@ -454,6 +466,7 @@ func TestHandleLoginPage(t *testing.T) {
 	assert.Contains(t, responseBody, "<form")
 	assert.Contains(t, responseBody, "method=\"post\"")
 	assert.Contains(t, responseBody, "action=\"/login\"")
+	assert.NotContains(t, responseBody, "name=\"username\"")
 }
 
 func TestNormalizeBrandColor(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -303,7 +303,7 @@ func (wb *Web) router() (http.Handler, error) {
 // It uses a multi-tiered authentication approach:
 // 1. Login page (/login) and static assets are always accessible without authentication
 // 2. Checks for a valid authentication cookie first
-// 3. Falls back to HTTP Basic Auth with username "weblist" and password from config
+// 3. Falls back to HTTP Basic Auth with the configured username and password
 // 4. On successful Basic Auth, sets a cookie for future requests to avoid repeated authentication
 // 5. Redirects unauthenticated requests to the login page
 // This middleware belongs after all other middleware but before route handlers.

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -38,8 +38,6 @@
             {{ end }}
             
             <form action="/login" method="post">
-                <input type="hidden" name="username" value="weblist">
-
                 <label for="password" style="width: 100%;">
                     <input type="password" id="password" name="password" placeholder="Enter your password" required autofocus style="width: 100%; box-sizing: border-box;">
                 </label>

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -100,7 +100,7 @@ weblist [options]
 - `-e, --exclude`: Files and directories to exclude (can be repeated) - env: `EXCLUDE`
 - `-f, --hide-footer`: Hide footer - env: `HIDE_FOOTER`
 - `-a, --auth`: Enable authentication with the specified password - env: `AUTH`
-- `--auth-user`: Username for authentication (default: `weblist`) - env: `AUTH_USER`
+- `--auth-user`: Username for HTTP Basic Auth (default: `weblist`) - env: `AUTH_USER`
 - `--session-secret`: Secret key for session tokens (auto-generated if not set) - env: `SESSION_SECRET`
 - `--session-ttl`: Session timeout duration (default: `24h`) - env: `SESSION_TTL`
 - `--insecure-cookies`: Allow cookies without secure flag - env: `INSECURE_COOKIES`
@@ -130,7 +130,7 @@ Weblist provides optional password protection for your file listings:
 # Enable authentication with a password
 weblist --auth your_password
 
-# Customize the username (default is "weblist")
+# Customize the HTTP Basic Auth username (default is "weblist")
 weblist --auth your_password --auth-user admin
 
 # Set a specific session secret key
@@ -144,8 +144,8 @@ weblist --auth your_password --insecure-cookies
 ```
 
 When authentication is enabled:
-- Users will be prompted with a login screen
-- The username is customizable via the `--auth-user` parameter (defaults to "weblist")
+- Browser login uses a password-only form
+- The HTTP Basic Auth username is customizable via `--auth-user` (defaults to "weblist")
 - The password is whatever you specify with the `--auth` parameter
 - Sessions are secured with HMAC-SHA256 signed tokens
 - Session secrets are automatically generated if not explicitly provided
@@ -357,7 +357,7 @@ services:
       - ROOT_DIR=/data
       - EXCLUDE=.git,.env
       - AUTH=your_password  # Optional: Enable password authentication
-      - AUTH_USER=admin  # Optional: Custom username for authentication (default: weblist)
+      - AUTH_USER=admin  # Optional: HTTP Basic Auth username (default: weblist)
       - SESSION_SECRET=your_secure_key  # Optional: Secret for signing session tokens
       - SESSION_TTL=24h  # Optional: Session timeout duration
       - BRAND_NAME=My Company  # Optional: Display company name in navbar


### PR DESCRIPTION
makes the browser login password-only, so a custom `--auth-user` no longer locks users out of the web UI.

### the bug

`login.html` posted `<input type="hidden" name="username" value="weblist">`, while `handleLoginSubmit` compared the posted username against the configured `AuthUser`. With `--auth-user=alice`, the form always posted `weblist`, the comparison failed, and browser login was impossible. Basic Auth was unaffected because the client supplies its username.

### the fix

the browser form did not ask for a username; its hidden value came from the page, so the comparison added no credential. Both the field and the username comparison are gone. The form now validates only the password and reports `Invalid password` on failure.

`--auth-user` remains supported for HTTP Basic Auth. `tryBasicAuth` and `getAuthUser` are unchanged. `POST /login` accepts a password alone and ignores any `username` field, preserving scripted clients that still send it.

the docs now identify `--auth-user` as the HTTP Basic Auth username and the browser form as password-only, in four places each. SFTP uses its own `--sftp.user`; that text was already correct.

### tests

the old wrong-username case was replaced with `posted username is ignored`, which asserts a 303 for absent and wrong usernames. The success case uses a custom `AuthUser`, the rendered page has no username input, and the E2E auth server runs with `--auth-user=customuser`.

checked against a live binary with `--auth=secret123 --auth-user=alice`: a password-only form post returns 303, a wrong password renders `Invalid password`, `alice:secret123` over Basic Auth returns 200, and `weblist:secret123` is rejected.

Fix #52
